### PR TITLE
EasyBuild sources in subdir by version and prep for rsync upgrade.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -33,15 +33,18 @@
       mode: 'pull'
       use_ssh_args: 'yes'
       rsync_opts:
-        # --omit-dir-times Is required to prevent "sync error: some files/attrs were not transferred"
-        #                  for file systems like NFS mounts that cannot handle setting dir times properly.
-        # --chmod          Is required to prevent errors when the perms on the source are not what is required/expected on the destination.
-        #                  Fixing perms on the source would be good, but that may be out of our control.
-        #                  In that case --chmod ensures we get what we want on the destination.
-        # --force          Is required when symlinks have changed into dirs/files or vice versa.
-        #                  In that case the wrong outdated stuff has to be deleted on the destination first before the new stuff can be created.
-        #                  Deleting the outdated stuff may fail without --force.
+        # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
+        #                   for file systems like NFS mounts that cannot handle setting dir times properly.
+        # --omit-link-times Is required to prevent "sync error: some files/attrs were not transferred"
+        #                   for file systems like NFS mounts that cannot handle setting dir times properly.
+        # --chmod           Is required to prevent errors when the perms on the source are not what is required/expected on the destination.
+        #                   Fixing perms on the source would be good, but that may be out of our control.
+        #                   In that case --chmod ensures we get what we want on the destination.
+        # --force           Is required when symlinks have changed into dirs/files or vice versa.
+        #                   In that case the wrong outdated stuff has to be deleted on the destination first before the new stuff can be created.
+        #                   Deleting the outdated stuff may fail without --force.
         - "--omit-dir-times"
+        #- "--omit-link-times" -> Does not work on rsync < 3.1.2, so we cannot use this on CentOS 6. Enable after upgrade to CentOS 7.
         - "--chmod={{ MODE_D2775_F0664 }}"
         - "--force"
     delegate_to: "{{ inventory_hostname }}"
@@ -69,11 +72,12 @@
       mode: 'pull'
       use_ssh_args: 'yes'
       rsync_opts:
-        # --relative       In combination with a "source_server:some/path/not/created/on/destination/./path/created/on/destination/some_file" (dot dir)
-        #                  recreates a partial dir structure on the destination relative to the /./ dir, when it does not already exist.
-        #                  Without this combination of --relative and dot dir rsync will error when the path does not exist on the destination.
+        # --relative        In combination with a "source_server:some/path/not/created/on/destination/./path/created/on/destination/some_file" (dot dir)
+        #                   recreates a partial dir structure on the destination relative to the /./ dir, when it does not already exist.
+        #                   Without this combination of --relative and dot dir rsync will error when the path does not exist on the destination.
         - '--relative'
         - '--omit-dir-times'               # See comments above for why.
+        #- "--omit-link-times" -> Does not work on rsync < 3.1.2, so we cannot use this on CentOS 6. Enable after upgrade to CentOS 7.
         - "--chmod={{ MODE_D2775_F0664 }}" # See comments above for why.
         - '--force'                        # See comments above for why.
     delegate_to: "{{ inventory_hostname }}"
@@ -123,6 +127,7 @@
       rsync_opts:
         - '--relative'                     # See comments above for why.
         - '--omit-dir-times'               # See comments above for why.
+        #- "--omit-link-times" -> Does not work on rsync < 3.1.2, so we cannot use this on CentOS 6. Enable after upgrade to CentOS 7.
         - "--chmod={{ MODE_D2775_F0664 }}" # See comments above for why.
         - '--force'                        # See comments above for why.
     delegate_to: "{{ inventory_hostname }}"

--- a/roles/easybuild-install/tasks/install_lua_lmod_easybuild.yml
+++ b/roles/easybuild-install/tasks/install_lua_lmod_easybuild.yml
@@ -57,22 +57,22 @@
   get_url: url="{{ item.url }}" dest="{{ item.dest }}" checksum="{{ item.checksum }}" mode="{{ MODE_0664_HARD }}"
   with_items:
     - url: "https://raw.githubusercontent.com/easybuilders/easybuild-framework/{{ easybuild_bs_hash }}/easybuild/scripts/bootstrap_eb.py"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb_{{ easybuild_bs_version }}.py"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/bootstrap_eb_{{ easybuild_bs_version }}.py"
       checksum: "{{ easybuild_bs_checksum }}"
     - url: "{{ easybuild_vsc_install_url }}"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
       checksum: "{{ easybuild_vsc_install_checksum }}"
     - url: "{{ easybuild_vsc_base_url }}"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
       checksum: "{{ easybuild_vsc_base_checksum }}"
     - url: "{{ easybuild_framework_url }}"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
       checksum: "{{ easybuild_framework_checksum }}"
     - url: "{{ easybuild_easyblocks_url }}"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
       checksum: "{{ easybuild_easyblocks_checksum }}"
     - url: "{{ easybuild_easyconfigs_url }}"
-      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
       checksum: "{{ easybuild_easyconfigs_checksum }}"
 - name: Install latest EasyBuild version with bootstrap script.
   #
@@ -81,8 +81,8 @@
   shell: |
          source ~/.modulesrc
          umask 0002
-         export EASYBUILD_BOOTSTRAP_SOURCEPATH="{{ easybuild_sources_dir }}/e/EasyBuild/"
-         python {{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb_{{ easybuild_bs_version }}.py {{ HPC_ENV_PREFIX }}
+         export EASYBUILD_BOOTSTRAP_SOURCEPATH="{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/"
+         python {{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}/bootstrap_eb_{{ easybuild_bs_version }}.py {{ HPC_ENV_PREFIX }}
 - name: Check if the required EasyBuild version is installed.
   shell: |
          source ~/.modulesrc >/dev/null 2>&1

--- a/roles/easybuild-install/tasks/main.yml
+++ b/roles/easybuild-install/tasks/main.yml
@@ -4,7 +4,7 @@
   with_items:
     - "{{ easybuild_sources_dir }}/l/Lmod"
     - "{{ easybuild_sources_dir }}/l/Lua"
-    - "{{ easybuild_sources_dir }}/e/EasyBuild"
+    - "{{ easybuild_sources_dir }}/e/EasyBuild/{{ easybuild_eb_version }}"
     - "{{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}"
     - "{{ easybuild_software_dir }}/EasyBuild/"
     - "{{ easybuild_modules_dir }}/all/EasyBuild"


### PR DESCRIPTION
* Store EasyBuild bootstrap sources in version specific dir.
   Otherwise the bootstrap script will fail when there are vsc-* source files for more than one version.
* Added disabled --omit-link-times option for rsync in preparation for upgrade to rsync >= 3.1.2.