### PR TITLE
Update to new synchronize task from ansible.posix collection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,27 +32,6 @@ The deployment consists of the following steps:
  - A basic understanding of Ansible (See: http://docs.ansible.com/ansible/latest/intro_getting_started.html#)
  - A basic understanding of EasyBuild not required to deploy the pipeline ''as is'', but will come in handy when updating/modifying the pipeline and it's dependencies.
 
-#### Ansible & environment patches
-
-Various parts of the Ansible playbook use rsync to copy data to the target host.
-Unfortunately the Ansible rsync wrapper module contains a few bugs.
-These bugs must be patched on the control host:
-
- - [Bugfix for bug #17492 "Do not prepend PWD when path is in form user@server:path or server:path"](https://github.com/ansible-collections/ansible.posix/pull/118)
- - [Bugfix for bug #24365 "Added option to allow SSH connection multiplixing"](https://github.com/ansible-collections/ansible.posix/pull/120)
- - Both bugs are in a file named ```synchronize.py```, but one is a _module_ and the other is an _action_ with the same name.
- - On macOS with Ansible installed using HomeBrew you will find these files in:  
-   For Ansible <= 2.9.x:  
-   ```
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible/modules/files/synchronize.py
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible/modules/files/synchronize.py
-   ```
-   For Ansible >= 2.10.x:  
-   ```
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible_collections/ansible/posix/plugins/action/synchronize.py
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible_collections/ansible/posix/plugins/modules/synchronize.py
-   ```
-
 In addition you must add to ```~/.ssh/config``` on the target host from the inventory and for the user running the playbook:
 ```
 #
@@ -80,7 +59,15 @@ ControlPersist 5m
  - Illumina data from human samples.
    - When you have data from a different sequencing platform you may need to tweak analysis steps.
    - When you have data from a different species you will need to modify the playbook to provision reference data for that species.
-   
+
+## Dependencies from Ansible Galaxy
+
+You can fetch dependencies from Ansible Galaxy on the control host with:
+
+```bash
+ansible-galaxy install -r galaxy-requirements.yml
+```
+
 ## Defaults and how to overrule them
 
 The default values for variables (like the version number of the pipeline to deploy) are stored in:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ControlPersist 5m
 You can fetch dependencies from Ansible Galaxy on the control host with:
 
 ```bash
-ansible-galaxy install -r galaxy-requirements.yml
+ansible-galaxy install -r requirements.yml
 ```
 
 ## Defaults and how to overrule them

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: ansible.posix
+    version: '>=1.2.0'
+...

--- a/roles/fetch-sources-and-refdata/tasks/main.yml
+++ b/roles/fetch-sources-and-refdata/tasks/main.yml
@@ -22,11 +22,12 @@
     - "{{ HPC_ENV_PREFIX }}/data"
 
 - name: Synchronize reference data.
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ remote_env_cache_dir_public }}/data/{{ item }}"
     dest: "{{ HPC_ENV_PREFIX }}/data/"
     mode: 'pull'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
       #                   for file systems like NFS mounts that cannot handle setting dir times properly.
@@ -48,11 +49,12 @@
 
 - name: Synchronize publicly available sources, which cannot be downloaded automagically by EB for technical reasons.
   # This is usually the case for downloads from FTP URLs, which may be blocked by firewalls due to the insecure nature of FTP.
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ remote_env_cache_dir_public }}/sources/./{{ item }}"
     dest: "{{ easybuild_sources_dir }}/"
     mode: 'pull'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       # --relative        In combination with a "source_server:some/path/not/created/on/destination/./path/created/on/destination/some_file" (dot dir)
       #                   recreates a partial dir structure on the destination relative to the /./ dir, when it does not already exist.
@@ -68,11 +70,12 @@
 - name: Synchronize sources, which cannot be downloaded automagically by EasyBuild for legal reasons.
   # NOTE: This is more or less the same as the download above, but for legal reasons we cannot cache these on a publicly accessible server.
   #       You will have to download these yourself to a system under your control, so the playbook can copy them to your target systems.
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ remote_env_cache_dir_private }}/sources/./{{ item }}"
     dest: "{{ easybuild_sources_dir }}/"
     mode: 'pull'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       - '--relative'                     # See comments above for why.
       - '--omit-dir-times'               # See comments above for why.


### PR DESCRIPTION
The new `ansible.posix.synchronize` task has two bug fixes, so we no longer need to patch Ansible after each update :).