### PR TITLE
Feature: install only required easyconfigs on helper machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ git pull blessed master
 #
 # Activate virtual environment.
 #
-source ansible.venv/bin/
+source ansible.venv/bin/activate
 #
 # Run complete playbook: general syntax
 #

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -17,7 +17,7 @@
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.44'
+extra_easyconfigs_version: '2.8.51'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -17,7 +17,7 @@
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.44'
+extra_easyconfigs_version: '2.8.51'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/leucinezipper_cluster/vars.yml
+++ b/group_vars/leucinezipper_cluster/vars.yml
@@ -17,7 +17,7 @@
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.50'
+extra_easyconfigs_version: '2.8.51'
 #
 # Group folder structures to construct on shared storage systems.
 #
@@ -58,21 +58,21 @@ group_subfolder_structure: [
 #
 group_module_versions:
   umcg-atd:
-    NGS_Automated: 3.7.1
-    NGS_DNA: 3.6.0
+    NGS_Automated: 3.8.0
+    NGS_DNA: 3.7.0
     ConcordanceCheck: 2.1.0
   umcg-gd:
     NGS_Automated: 3.7.1
     NGS_DNA: 3.6.0
     ConcordanceCheck: 2.1.0
   umcg-gsad:
-    NGS_Automated: 3.7.1
+    NGS_Automated: 3.8.0
     GAP: 2.3.1
   umcg-gap:
     NGS_Automated: 3.6.2
     GAP: 2.3.1
   umcg-gst:
-    NGS_Automated: 3.7.1
+    NGS_Automated: 3.8.0
   umcg-genomescan:
     NGS_Automated: 3.6.2
   umcg-labgnkbh:
@@ -638,5 +638,8 @@ dynamic_easyconfigs: >-
 static_easyconfigs:
   - c/cluster-utils/cluster-utils-v18.08.1.eb
   - d/depad-utils/depad-utils-v19.02.1.eb
-easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+all_easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+easyconfigs: "{{ all_easyconfigs }}"
+helper_only_easyconfigs: "{{ all_easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') | list }}"
+
 ...

--- a/group_vars/leucinezipper_cluster/vars.yml
+++ b/group_vars/leucinezipper_cluster/vars.yml
@@ -67,7 +67,7 @@ group_module_versions:
     ConcordanceCheck: 2.1.0
   umcg-gsad:
     NGS_Automated: 3.8.0
-    GAP: 2.3.1
+    GAP: 2.5.0
   umcg-gap:
     NGS_Automated: 3.6.2
     GAP: 2.3.1

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -17,7 +17,7 @@
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.5.1'
-extra_easyconfigs_version: '2.8.50'
+extra_easyconfigs_version: '2.8.51'
 #
 # Group folder structures to construct on shared storage systems.
 #
@@ -58,21 +58,21 @@ group_subfolder_structure: [
 #
 group_module_versions:
   umcg-atd:
-    NGS_Automated: 3.7.1
-    NGS_DNA: 3.6.0
+    NGS_Automated: 3.8.0
+    NGS_DNA: 3.7.0
     ConcordanceCheck: 2.1.0
   umcg-gd:
     NGS_Automated: 3.7.1
     NGS_DNA: 3.6.0
     ConcordanceCheck: 2.1.0
   umcg-gsad:
-    NGS_Automated: 3.7.1
+    NGS_Automated: 3.8.0
     GAP: 2.3.1
   umcg-gap:
     NGS_Automated: 3.6.2
     GAP: 2.3.1
   umcg-gst:
-    NGS_Automated: 3.7.1
+    NGS_Automated: 3.8.0
   umcg-genomescan:
     NGS_Automated: 3.6.2
   umcg-labgnkbh:
@@ -618,5 +618,8 @@ static_easyconfigs:
   - c/cluster-utils/cluster-utils-v21.05.1-GCCcore-7.3.0.eb
   - d/depad-utils/depad-utils-v19.10.1.eb
   - n/NGS_DNA/NGS_DNA-4.0.5-foss-2018b.eb
-easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+all_easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+easyconfigs: "{{ all_easyconfigs }}"
+helper_only_easyconfigs: "{{ all_easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') | list }}"
+
 ...

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -67,7 +67,7 @@ group_module_versions:
     ConcordanceCheck: 2.1.0
   umcg-gsad:
     NGS_Automated: 3.8.0
-    GAP: 2.3.1
+    GAP: 2.5.0
   umcg-gap:
     NGS_Automated: 3.6.2
     GAP: 2.3.1

--- a/group_vars/zincfinger_cluster/vars.yml
+++ b/group_vars/zincfinger_cluster/vars.yml
@@ -639,4 +639,5 @@ static_easyconfigs:
   - c/cluster-utils/cluster-utils-v18.08.1.eb
   - d/depad-utils/depad-utils-v19.02.1.eb
 easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+easyconfigs_helper_only: "{{ easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') }}"
 ...

--- a/group_vars/zincfinger_cluster/vars.yml
+++ b/group_vars/zincfinger_cluster/vars.yml
@@ -639,5 +639,6 @@ static_easyconfigs:
   - c/cluster-utils/cluster-utils-v18.08.1.eb
   - d/depad-utils/depad-utils-v19.02.1.eb
 all_easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+easyconfigs: "{{ all_easyconfigs }}"
 helper_only_easyconfigs: "{{ all_easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') | list }}"
 ...

--- a/group_vars/zincfinger_cluster/vars.yml
+++ b/group_vars/zincfinger_cluster/vars.yml
@@ -638,6 +638,6 @@ dynamic_easyconfigs: >-
 static_easyconfigs:
   - c/cluster-utils/cluster-utils-v18.08.1.eb
   - d/depad-utils/depad-utils-v19.02.1.eb
-easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
-easyconfigs_helper_only: "{{ easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') }}"
+all_easyconfigs: "{{ dynamic_easyconfigs | default([]) | union(static_easyconfigs | default([])) }}"
+helper_only_easyconfigs: "{{ all_easyconfigs | select('search', 'NGS_Automated-.*-bare.eb') | list }}"
 ...

--- a/single_role_playbooks/install_modules_with_easybuild.yml
+++ b/single_role_playbooks/install_modules_with_easybuild.yml
@@ -3,15 +3,13 @@
 
 - hosts:
     - deploy_admin_interface
-  vars:
-    easyconfigs: "{{ all_easyconfigs | default(easyconfigs) }}"
   roles:
     - install_modules_with_easybuild
 
 - hosts:
     - helper
   vars:
-    easyconfigs: "{{ helper_only_easyconfigs }}"
+    easyconfigs: "{{ helper_only_easyconfigs | default([]) }}"
   roles:
     - install_modules_with_easybuild
 ...

--- a/single_role_playbooks/install_modules_with_easybuild.yml
+++ b/single_role_playbooks/install_modules_with_easybuild.yml
@@ -3,7 +3,13 @@
 
 - hosts:
     - deploy_admin_interface
+  roles:
+    - install_modules_with_easybuild
+
+- hosts:
     - helper
+  vars:
+    easyconfigs: "{{ easyconfigs_helper_only }}"
   roles:
     - install_modules_with_easybuild
 ...

--- a/single_role_playbooks/install_modules_with_easybuild.yml
+++ b/single_role_playbooks/install_modules_with_easybuild.yml
@@ -3,13 +3,15 @@
 
 - hosts:
     - deploy_admin_interface
+  vars:
+    easyconfigs: "{{ all_easyconfigs | default(easyconfigs) }}"
   roles:
     - install_modules_with_easybuild
 
 - hosts:
     - helper
   vars:
-    easyconfigs: "{{ easyconfigs_helper_only }}"
+    easyconfigs: "{{ helper_only_easyconfigs }}"
   roles:
     - install_modules_with_easybuild
 ...


### PR DESCRIPTION
* Override list of `easyconfigs` to install on `helpers`, so we do not try to install software with lots of deps we do not need  and/or do not compile on these machines.
* Updated software versions for test groups on Leucine-Zipper and Winged-Helix to make it in sync with what we already have on Zinc-Finger.