### PR TITLE
Fix/various

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -216,6 +216,20 @@ crontabs:
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load ConcordanceCheck/{{ group_module_versions['umcg-atd']['ConcordanceCheck'] }};
          cleanup.sh -g umcg-atd"
+  - name: ConcordanceCheck_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-atd-dm
+    machines: "{{ groups['helper'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-atd']['ConcordanceCheck'] }};
+         notifications.sh -g umcg-atd -e"
+  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-atd-dm
+    machines: "{{ groups['helper'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-atd']['ConcordanceCheck'] }};
+         cleanup.sh -g umcg-atd"
   ######################################################################################################################
   # umcg-gd group
   ######################################################################################################################
@@ -348,6 +362,20 @@ crontabs:
   - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+         cleanup.sh -g umcg-gd"
+  - name: ConcordanceCheck_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['helper'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+         notifications.sh -g umcg-gd -e"
+  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['helper'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};

--- a/roles/install_easybuild/tasks/install_easybuild.yml
+++ b/roles/install_easybuild/tasks/install_easybuild.yml
@@ -1,9 +1,9 @@
 ---
-- name: 'Install EasyBuild < 4.5 using boot strap script.'
+- name: 'Install EasyBuild < 4.3 using boot strap script.'
   include_tasks: tasks/install_easybuild_with_bootstrap_script.yml
-  when: easybuild_version is version('4.5', '<')
+  when: easybuild_version is version('4.3', '<')
 
-- name: 'Install EasyBuild >= 4.5 using boot strap script.'
+- name: 'Install EasyBuild >= 4.3 using pip.'
   include_tasks: tasks/install_easybuild_with_pip.yml
-  when: easybuild_version is version('4.5', '>=')
+  when: easybuild_version is version('4.3', '>=')
 ...


### PR DESCRIPTION
* [Added missing cronjobs for ConcordanceCheck also to Winged-Helix config.](https://github.com/molgenis/ansible-pipelines/commit/555d158f0de2dab30bc31d1f79f14654b1726c6e)
* [Lowered minimal version number to switch from bootstrap script to pip for installation of EasyBuild 4.5 -> 4.3.](https://github.com/molgenis/ansible-pipelines/commit/cd90395aa85653e2498cc864d61b595ea04520c8)
   This is required to install EasyBuild 4.3.x on the older CentOS machines, because the bootstrap script procedure does not work anymore on Python 2.6.x