### PR TITLE
Disabled cronjobs to fetch GS data on Leucine-Zipper and Winge-Helix.

### DIFF
--- a/group_vars/leucinezipper_cluster/vars.yml
+++ b/group_vars/leucinezipper_cluster/vars.yml
@@ -498,6 +498,7 @@ crontabs:
     user: umcg-gst-ateambot
     machines: "{{ groups['data_staging'] | default([]) }}"
     minute: '*/10'
+    disabled: true
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
          pullRawDataFromDS.sh -g umcg-gst"
@@ -529,6 +530,7 @@ crontabs:
     user: umcg-genomescan-ateambot
     machines: "{{ groups['data_staging'] | default([]) }}"
     minute: '*/10'
+    disabled: true
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
          pullRawDataFromDS.sh -g umcg-genomescan"

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -498,6 +498,7 @@ crontabs:
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
+    disabled: true
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
          pullRawDataFromDS.sh -g umcg-gst"
@@ -529,6 +530,7 @@ crontabs:
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
+    disabled: true
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
          pullRawDataFromDS.sh -g umcg-genomescan"


### PR DESCRIPTION
We currently have only one dedicated data transfer server and the data is fetched exclusively on Zinc-Finger.