### PR TITLE
WH: chaperone

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -31,6 +31,7 @@ chaperone
 [wingedhelix_cluster]
 wingedhelix
 wh-dai
+wh-chaperone
 
 [gattaca01_convertor]
 gattaca01
@@ -104,6 +105,7 @@ gattaca02
 [helper]
 chaperone
 coenzyme
+wh-chaperone
 
 ###########################################################################################
 # 3. Physical location / data center
@@ -124,6 +126,7 @@ talos
 tl-dai
 gearshift
 sugarsnax
+wh-chaperone
 
 [Embassy]
 hyperchicken
@@ -153,6 +156,7 @@ chaperone
 lz-ds
 wingedhelix
 wh-dai
+wh-chaperone
 gearshift
 sugarsnax
 fender

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -17,7 +17,7 @@
   ansible.builtin.pip:
     name: easybuild
     version: "{{ easybuild_version }}"
-    extra_args: '--install-option "--prefix={{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}/"'
+    extra_args: "--prefix={{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}/"
     executable: "{{ pip_path.stdout }}"
 - name: 'Get install suffix from pip -V'
   ansible.builtin.shell:


### PR DESCRIPTION
Updated pip EB install, as it returned error at installation:
```
    ERROR: Location-changing options found in --install-option: ['--prefix'] from command line. This is unsupported, use pip-level options li --user, --prefix, --root, and --target instead.
```
Seems that install-option is not needed, as prefix itself is working and installs the EB in the right place.