### PR TITLE
Ansible pipelines deployed on wh-chaperone

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -16,8 +16,8 @@
 #
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
-easybuild_version: '4.5.1'
-extra_easyconfigs_version: '2.8.53'
+easybuild_version: '4.5.5'
+extra_easyconfigs_version: '2.8.54'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -23,7 +23,7 @@
   ansible.builtin.shell:
     cmd: |
          set -o pipefail
-         find "{{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}" -name site-packages | grep -o 'lib[^ ]*python[^ ]*'
+         /usr/bin/find "{{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}" -name site-packages | grep -o 'lib[^ ]*python[^ ]*'
   register: python_install_suffix
   changed_when: true
 - name: 'Deploy Lua module file for EasyBuild.'

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -26,7 +26,7 @@
          "{{ pip_path.stdout }}" -V | grep -o 'lib[^ ]*python[^ ]*'
   register: python_install_suffix
   changed_when: true
-- name: 'Determine site-packages location for Lua module file to be correctly configured'
+- name: 'Determine site-packages location for Lua module file.'
   ansible.builtin.shell:
     cmd: |
          set -o pipefail

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -19,13 +19,6 @@
     version: "{{ easybuild_version }}"
     extra_args: "--prefix={{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}/"
     executable: "{{ pip_path.stdout }}"
-- name: 'Get install suffix from pip -V'
-  ansible.builtin.shell:
-    cmd: |
-         set -o pipefail
-         "{{ pip_path.stdout }}" -V | grep -o 'lib[^ ]*python[^ ]*'
-  register: python_install_suffix
-  changed_when: true
 - name: 'Determine site-packages location for Lua module file.'
   ansible.builtin.shell:
     cmd: |

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -23,7 +23,7 @@
   ansible.builtin.shell:
     cmd: |
          set -o pipefail
-         "{{ pip_path.stdout }}" -V | grep -o 'lib[^ ]*python[^ ]*'
+         find "{{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}" -name site-packages | grep -o 'lib[^ ]*python[^ ]*'
   register: python_install_suffix
   changed_when: true
 - name: 'Deploy Lua module file for EasyBuild.'

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -23,8 +23,15 @@
   ansible.builtin.shell:
     cmd: |
          set -o pipefail
-         /usr/bin/find "{{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}" -name site-packages | grep -o 'lib[^ ]*python[^ ]*'
+         "{{ pip_path.stdout }}" -V | grep -o 'lib[^ ]*python[^ ]*'
   register: python_install_suffix
+  changed_when: true
+- name: 'Determine site-packages location for Lua module file to be correctly configured'
+  ansible.builtin.shell:
+    cmd: |
+         set -o pipefail
+         /usr/bin/find "{{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}" -name "site-packages" | grep -o 'lib[^ ]*python[^ ]*'
+  register: pythonpath
   changed_when: true
 - name: 'Deploy Lua module file for EasyBuild.'
   ansible.builtin.template:

--- a/roles/install_easybuild/templates/EasyBuildModule.lua
+++ b/roles/install_easybuild/templates/EasyBuildModule.lua
@@ -28,5 +28,5 @@ setenv("EBROOTEASYBUILD", root)
 setenv("EBVERSIONEASYBUILD", "{{ easybuild_version }}")
 setenv("EBDEVELEASYBUILD", pathJoin(root, "easybuild/EasyBuild-{{ easybuild_version }}-easybuild-devel"))
 
-prepend_path("PYTHONPATH", pathJoin(root, "{{ python_install_suffix.stdout }}"))
+prepend_path("PYTHONPATH", pathJoin(root, "{{ pythonpath.stdout }}"))
 -- Deployed with Ansible


### PR DESCRIPTION
- version updated from 4.5.1 to 4.5.5, as the version 4.5.1 had issues on wh-chaperone having missing `easybuild.main` file after installation (bug)
- the `PYTHONPATH` was incorrectly defined to
`/apps/software//EasyBuild/4.5.5/lib64/python3.6/site-packages/pip`
instead of
`/apps/software/EasyBuild/4.5.5/lib/python3.6/site-packages`