### PR TITLE
Updated easyconfigs and implemented takeiteasy

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -16,7 +16,9 @@ easybuild_sources_dir: "{{ hpc_env_prefix }}/sources/"
 easybuild_modules_dir: "{{ hpc_env_prefix }}/modules/"
 easybuild_software_dir: "{{ hpc_env_prefix }}/software/"
 easybuild_modules_syntax: 'Lua'
-extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/easybuild-easyconfigs-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
+extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 remote_env_cache_dir_public:  'f114592@ssh.webhosting.rug.nl:site/apps/'
 remote_env_cache_dir_private: 'f114592@ssh.webhosting.rug.nl:rsync-only/apps/'
 configure_env_in_cronjob: 'export SOURCE_HPC_ENV="True"; . ~/.bashrc'
@@ -145,4 +147,6 @@ extra_easyconfigs_releases:
     checksum: 'sha256:3f4be5068bb98bd74cd49f7ae26aa0a4e1c6aa8313c4e1ecc11211fa6f13bcdd'
   2.8.57:
     checksum: 'sha256:e5a3d4a8e6dd087ee8991bd5d5cb36d79875ebcb1c3d867b415e6c7a83595221'
+  1.0:
+    checksum: 'sha256:62caec4126fa00bf03587f9f4db15f63b4216c83a49bad9c6a77b192838ed581'
 ...

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'bb'
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'cf'
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'fd'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.51'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #
@@ -45,8 +46,8 @@ public_sources: [
 private_sources: []
 refdata: []
 easyconfigs: [
-  'c/cluster-utils/cluster-utils-v21.05.1-GCCcore-7.3.0.eb',
-  'd/depad-utils/depad-utils-v19.10.1.eb',
+  'c/cluster-utils/cluster-utils-v22.10.2-GCCcore-7.3.0.eb',
+  'd/depad-utils/depad-utils-v21.02.1.eb',
   'n/NGS_Suite/NGS_Suite-2020.10.1-foss-2018b.eb',
   'n/ngs-bits/ngs-bits-2019_11-GCCcore-7.3.0.eb',
 ]

--- a/group_vars/gattaca01_convertor/vars.yml
+++ b/group_vars/gattaca01_convertor/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'g1'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/gattaca02_convertor/vars.yml
+++ b/group_vars/gattaca02_convertor/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'g2'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'gs'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.57'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'hc'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/leucinezipper_cluster/vars.yml
+++ b/group_vars/leucinezipper_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'lz'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'nb'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/spider_cluster/vars.yml
+++ b/group_vars/spider_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'sd'
 lua_version: '5.3.4'
 lmod_version: '8.6.2'
 easybuild_version: '4.5.1'
-extra_easyconfigs_version: '2.8.48'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'tl'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.44'
+extra_easyconfigs_version: 1.0
+extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'wh'
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.6.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/group_vars/zincfinger_cluster/vars.yml
+++ b/group_vars/zincfinger_cluster/vars.yml
@@ -17,7 +17,8 @@ stack_prefix: 'zf'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.3.2'
-extra_easyconfigs_version: '2.8.54'
+extra_easyconfigs_version: 2.8.54
+extra_easyconfigs_repository: 'easybuild-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
 #

--- a/roles/fetch_extra_easyconfigs/tasks/main.yml
+++ b/roles/fetch_extra_easyconfigs/tasks/main.yml
@@ -15,7 +15,7 @@
     checksum: "{{ item.checksum }}"
     mode: "{{ MODE_0664_HARD }}"
   with_items:
-    - url: "https://github.com/molgenis/easybuild-easyconfigs/archive/{{ extra_easyconfigs_version }}.tar.gz"
+    - url: "https://github.com/molgenis/{{ extra_easyconfigs_repository }}/archive/{{ extra_easyconfigs_version }}.tar.gz"
       dest: "{{ easybuild_sources_dir }}/e/easyconfigs/"
       checksum: "{{ extra_easyconfigs_releases[extra_easyconfigs_version]['checksum'] }}"
 
@@ -26,6 +26,6 @@
     remote_src: true
     mode: "{{ MODE__775_SOFT }}"
   with_items:
-    - src: "{{ easybuild_sources_dir }}/e/easyconfigs/easybuild-easyconfigs-{{ extra_easyconfigs_version }}.tar.gz"
+    - src: "{{ easybuild_sources_dir }}/e/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}.tar.gz"
       dest: "{{ easybuild_software_dir }}/easyconfigs"
 ...

--- a/roles/install_easybuild/handlers/main.yml
+++ b/roles/install_easybuild/handlers/main.yml
@@ -12,11 +12,11 @@
 ---
 - name: Install_Lua
   listen: Install_Lua
-  include_tasks: tasks/install_lua.yml
+  ansible.builtin.include_tasks: tasks/install_lua.yml
 - name: Install_Lmod
   listen: Install_Lmod
-  include_tasks: tasks/install_lmod.yml
+  ansible.builtin.include_tasks: tasks/install_lmod.yml
 - name: Install_EasyBuild
   listen: Install_EasyBuild
-  include_tasks: tasks/install_easybuild.yml
+  ansible.builtin.include_tasks: tasks/install_easybuild.yml
 ...

--- a/roles/install_easybuild/tasks/install_easybuild.yml
+++ b/roles/install_easybuild/tasks/install_easybuild.yml
@@ -1,9 +1,9 @@
 ---
 - name: 'Install EasyBuild < 4.3 using boot strap script.'
-  include_tasks: tasks/install_easybuild_with_bootstrap_script.yml
+  ansible.builtin.include_tasks: tasks/install_easybuild_with_bootstrap_script.yml
   when: easybuild_version is version('4.3', '<')
 
 - name: 'Install EasyBuild >= 4.3 using pip.'
-  include_tasks: tasks/install_easybuild_with_pip.yml
+  ansible.builtin.include_tasks: tasks/install_easybuild_with_pip.yml
   when: easybuild_version is version('4.3', '>=')
 ...

--- a/single_role_playbooks/fetch_extra_easyconfigs.yml
+++ b/single_role_playbooks/fetch_extra_easyconfigs.yml
@@ -1,7 +1,9 @@
 ---
-- import_playbook: pre_deploy_checks.yml
+- name: Calling pre-deploy checks
+  import_playbook: pre_deploy_checks.yml
 
-- hosts:
+- name: Fetching extra easyconfigs
+  hosts:
     - deploy_admin_interface
     - chaperone
   roles:

--- a/single_role_playbooks/install_easybuild.yml
+++ b/single_role_playbooks/install_easybuild.yml
@@ -1,7 +1,9 @@
 ---
-- import_playbook: pre_deploy_checks.yml
+- name: Calling pre-deploy checks
+  import_playbook: pre_deploy_checks.yml
 
-- hosts:
+- name: Installing EasyBuild
+  hosts:
     - deploy_admin_interface
     - chaperone
   roles:

--- a/single_role_playbooks/pre_deploy_checks.yml
+++ b/single_role_playbooks/pre_deploy_checks.yml
@@ -40,7 +40,7 @@
   any_errors_fatal: true
   become: false
   tasks:
-    - name: "Create remote tmp dir in {{ hpc_env_prefix }}/.tmp/"
+    - name: "Create remote '.tmp/' dir in {{ hpc_env_prefix }}"
       ansible.builtin.file:
         path: "{{ hpc_env_prefix }}/.tmp/"
         state: 'directory'


### PR DESCRIPTION
Each gruop has set it's own configuration to point to the correct molgenis repository
New (takeiteasy) tested with deployment on Hyperchicken, old (mogenis/easyconfigs) tested by deploying on Copperfist.
Updated to be compliant with ansible-lint (the lint now also complains about:
`Jinja templates should only be at the end of 'name'`