### PR TITLE
Bugfix: user on dat must be *-dm instead of *-ateambot.

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -224,7 +224,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-atd
     lfs: dat05
-    user: umcg-atd-ateambot
+    user: umcg-atd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -255,7 +255,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gd
     lfs: dat05
-    user: umcg-gd-ateambot
+    user: umcg-gd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -286,7 +286,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gsad
     lfs: dat05
-    user: umcg-gsad-ateambot
+    user: umcg-gsad-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -317,7 +317,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gap
     lfs: dat05
-    user: umcg-gap-ateambot
+    user: umcg-gap-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-array-dataverwerking
@@ -348,7 +348,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gst
     lfs: dat05
-    user: umcg-gst-ateambot
+    user: umcg-gst-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -372,7 +372,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-genomescan
     lfs: dat05
-    user: umcg-genomescan-ateambot
+    user: umcg-genomescan-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -389,7 +389,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-labgnkbh
     lfs: dat45
-    user: umcg-labgnkbh-ateambot
+    user: umcg-labgnkbh-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_labgnkbh
@@ -406,7 +406,7 @@ group_notification_targets:
   ######################################################################################################################
   - group: umcg-patho
     lfs: dat35
-    user: umcg-patho-ateambot
+    user: umcg-patho-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_patho

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -224,7 +224,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-atd
     lfs: dat06
-    user: umcg-atd-ateambot
+    user: umcg-atd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -255,7 +255,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gd
     lfs: dat06
-    user: umcg-gd-ateambot
+    user: umcg-gd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -286,7 +286,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gsad
     lfs: dat06
-    user: umcg-gsad-ateambot
+    user: umcg-gsad-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -317,7 +317,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gap
     lfs: dat06
-    user: umcg-gap-ateambot
+    user: umcg-gap-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-array-dataverwerking
@@ -348,7 +348,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gst
     lfs: dat06
-    user: umcg-gst-ateambot
+    user: umcg-gst-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -372,7 +372,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-genomescan
     lfs: dat06
-    user: umcg-genomescan-ateambot
+    user: umcg-genomescan-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -389,7 +389,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-labgnkbh
     lfs: dat46
-    user: umcg-labgnkbh-ateambot
+    user: umcg-labgnkbh-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_labgnkbh
@@ -406,7 +406,7 @@ group_notification_targets:
   ######################################################################################################################
   - group: umcg-patho
     lfs: dat36
-    user: umcg-patho-ateambot
+    user: umcg-patho-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_patho

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -224,7 +224,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-atd
     lfs: dat07
-    user: umcg-atd-ateambot
+    user: umcg-atd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -255,7 +255,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gd
     lfs: dat07
-    user: umcg-gd-ateambot
+    user: umcg-gd-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -286,7 +286,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gsad
     lfs: dat07
-    user: umcg-gsad-ateambot
+    user: umcg-gsad-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -317,7 +317,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gap
     lfs: dat07
-    user: umcg-gap-ateambot
+    user: umcg-gap-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-array-dataverwerking
@@ -348,7 +348,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-gst
     lfs: dat07
-    user: umcg-gst-ateambot
+    user: umcg-gst-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk
@@ -372,7 +372,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-genomescan
     lfs: dat07
-    user: umcg-genomescan-ateambot
+    user: umcg-genomescan-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_gd-ngs-dataverwerking
@@ -389,7 +389,7 @@ group_notification_targets:
     machines: "{{ groups['user_interface'] }}"
   - group: umcg-labgnkbh
     lfs: dat47
-    user: umcg-labgnkbh-ateambot
+    user: umcg-labgnkbh-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_labgnkbh
@@ -406,7 +406,7 @@ group_notification_targets:
   ######################################################################################################################
   - group: umcg-patho
     lfs: dat37
-    user: umcg-patho-ateambot
+    user: umcg-patho-dm
     type: notification_webhooks
     analysis_phases: [moveAndCheckSamplesheets]
     notification_target: hpc-helpdesk_and_patho

--- a/repo-init
+++ b/repo-init
@@ -27,13 +27,13 @@ export REPO_DIR="$( cd -P "$( dirname "${BASH_SOURCE:-}" )" && pwd )"
 #
 
 function repo-config() {
-	local _opt_nounset_was_enbled
+	local _previous_opt_nounset_state
 	if [[ -o nounset ]]; then
-		_opt_nounset_was_enbled='true'
+		_previous_opt_nounset_state='-u'
 	else
-		_opt_nounset_was_enbled='false'
-		set -u
+		_previous_opt_nounset_state='+u'
 	fi
+	set -u
 	#
 	# Check if Python venv was initialized.
 	#
@@ -41,6 +41,7 @@ function repo-config() {
 		printf 'ERROR: ${VIRTUAL_ENV} is empty.\n'
 		printf 'FATAL: The code from this repo requires Ansible and its dependencies installed in a Python virtual environment.\n'
 		printf 'FATAL: See the README.md for instructions.\n'
+		set "${_previous_opt_nounset_state}"
 		return 1
 	fi
 	#
@@ -49,12 +50,14 @@ function repo-config() {
 	local _stack_prefix="${1-}"
 	if [[ -z "${_stack_prefix:-}" ]]; then
 		printf '%s\n' 'ERROR: must specify an infra stack prefix.'
-		return
+		set "${_previous_opt_nounset_state}"
+		return 1
 	fi
 	local _group_vars="$(grep "^stack_prefix: ['\"]*${_stack_prefix}['\"]*$" "${REPO_DIR}/group_vars/"*/vars.yml | sed 's|:.*||')"
 	if [[ -z "${_group_vars:-}" ]]; then
 		printf '%s\n' "ERROR: cannot find group_vars/*/vars.yml for infra stack prefix ${_stack_prefix}."
-		return
+		set "${_previous_opt_nounset_state}"
+		return 1
 	fi
 	local _stack_name="$(basename "$(dirname "${_group_vars}")")"
 	declare -a _required_paths=(
@@ -66,7 +69,8 @@ function repo-config() {
 	for _required_path in "${_required_paths[@]}"; do
 		if [[ ! -e "${_required_path}" ]]; then
 			printf '%s\n' "ERROR: ${_required_path} does not exist for infra stack prefix ${_stack_prefix}."
-			return
+			set "${_previous_opt_nounset_state}"
+			return 1
 		fi
 	done
 	#
@@ -113,7 +117,5 @@ function repo-config() {
 		printf 'WARNING: Could not find Mitogen strategy plugin in %s\n' "${_ansible_mitogen_search_path}"
 		printf 'INFO: Mitogen strategy plugin is:        %s.\n' 'disabled (default)'
 	fi
-	if [[ "${_opt_nounset_was_enbled}" == 'false' ]]; then
-		set +u
-	fi
+	set "${_previous_opt_nounset_state}"
 }

--- a/roles/manage_notifications/tasks/main.yml
+++ b/roles/manage_notifications/tasks/main.yml
@@ -1,4 +1,23 @@
 ---
+#
+# Workaround for bug https://github.com/ansible/ansible/issues/56243
+# Was fixed in more recent Ansible, but that requires a newer Python 3,
+# which is not available on CentOS/RHEL 8, which is stuck at Python 3.6.
+#
+- name: Ensure file already exists at template dest to work around 'invalid selinux context' bug.
+  ansible.builtin.file:
+    path: "{{ hpc_groups_prefix }}/{{ notification_config.group }}/{{ notification_config.lfs }}/logs/\
+           {{ notification_config.notification_target }}.{{ notification_config.type }}"
+    owner: "{{ notification_config.user }}"
+    group: "{{ notification_config.group }}"
+    mode: '0600'
+    state: touch
+  loop: "{{ group_notification_targets | default([]) }}"
+  loop_control:
+    loop_var: notification_config
+    label: "{{ hpc_groups_prefix }}/{{ notification_config.group }}/{{ notification_config.lfs }}/logs/\
+            {{ notification_config.notification_target }}.{{ notification_config.type }}"
+
 - name: 'Create files with notification targets.'
   ansible.builtin.template:
     src: notification_targets.j2

--- a/roles/manage_notifications/tasks/main.yml
+++ b/roles/manage_notifications/tasks/main.yml
@@ -3,6 +3,7 @@
 # Workaround for bug https://github.com/ansible/ansible/issues/56243
 # Was fixed in more recent Ansible, but that requires a newer Python 3,
 # which is not available on CentOS/RHEL 8, which is stuck at Python 3.6.
+# (CentOS/RHEL 8 is currently only used on [wh|cf|bb]-chaperone machines.)
 #
 - name: Ensure file already exists at template dest to work around 'invalid selinux context' bug.
   ansible.builtin.file:

--- a/roles/manage_notifications/tasks/main.yml
+++ b/roles/manage_notifications/tasks/main.yml
@@ -12,6 +12,9 @@
     group: "{{ notification_config.group }}"
     mode: '0600'
     state: touch
+  become: true
+  become_user: "{{ notification_config.user }}"
+  when: inventory_hostname in notification_config.machines
   loop: "{{ group_notification_targets | default([]) }}"
   loop_control:
     loop_var: notification_config


### PR DESCRIPTION
* Bugfix: user to create notification configs on `dat` folders must be `*-dm` instead of `*-ateambot`.
* Added workaround for "invalid selinux context" bug in `ansible.builtin.template` task on CentOS/RHEL 8 with python 3.6, which is the case for `[bb|cf|wh]-chaperone` VMs.
* Improved error handling in `repo-init`