### PR TITLE
Update/easybuild

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -151,6 +151,8 @@ extra_easyconfigs_releases:
     checksum: 'sha256:62caec4126fa00bf03587f9f4db15f63b4216c83a49bad9c6a77b192838ed581'
   1.2:
     checksum: 'sha256:bf6ac7b824df3e79829fbba094a25d619f9728ae26148519f54177eb460e8e30'
+  1.3:
+    checksum: 'sha256:2c547983e8bad92045fa94e7f7f01973c9b326ca538f016bda6d10557a4c7a7f'
 analysis_folders:
   AGCT:
     tmp:
@@ -224,6 +226,7 @@ analysis_folders:
       - concordance/ngs
       - concordance/results
       - concordance/samplesheets
+      - concordance/samplesheets/archive
       - concordance/tmp
     dat:
       - ConcordanceCheckOutput

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -16,8 +16,9 @@ stack_prefix: 'bb'
 #
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
-easybuild_version: '4.6.2'
-extra_easyconfigs_version: 1.2
+easybuild_version: '4.8.0'
+eb_user: umcg-envsync
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -16,8 +16,9 @@ stack_prefix: 'cf'
 #
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
-easybuild_version: '4.6.2'
-extra_easyconfigs_version: 1.2
+easybuild_version: '4.8.0'
+eb_user: umcg-envsync
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -16,8 +16,8 @@ stack_prefix: 'fd'
 #
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
-easybuild_version: '4.7.1'
-extra_easyconfigs_version: 1.0
+easybuild_version: '4.8.0'
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -16,8 +16,8 @@ stack_prefix: 'gs'
 #
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
-easybuild_version: '4.7.1'
-extra_easyconfigs_version: 1.0
+easybuild_version: '4.8.0'
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -16,8 +16,8 @@ stack_prefix: 'hc'
 #
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
-easybuild_version: '4.7.1'
-extra_easyconfigs_version: 1.0
+easybuild_version: '4.8.0'
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'nb'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.8.0'
-extra_easyconfigs_version: 1.0
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'tl'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.8.0'
-extra_easyconfigs_version: 1.0
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -16,8 +16,8 @@ stack_prefix: 'wh'
 #
 lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
-easybuild_version: '4.6.2'
-extra_easyconfigs_version: 1.2
+easybuild_version: '4.8.0'
+extra_easyconfigs_version: 1.3
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #

--- a/roles/fetch_extra_easyconfigs/tasks/main.yml
+++ b/roles/fetch_extra_easyconfigs/tasks/main.yml
@@ -7,6 +7,8 @@
   with_items:
     - "{{ extra_easyconfigs_prefix }}"
     - "{{ easybuild_sources_dir }}/e/easyconfigs"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Get EasyConfigs.
   ansible.builtin.get_url:
@@ -14,10 +16,13 @@
     dest: "{{ item.dest }}"
     checksum: "{{ item.checksum }}"
     mode: "{{ MODE_0664_HARD }}"
+    timeout: 30
   with_items:
     - url: "https://github.com/molgenis/{{ extra_easyconfigs_repository }}/archive/{{ extra_easyconfigs_version }}.tar.gz"
       dest: "{{ easybuild_sources_dir }}/e/easyconfigs/"
       checksum: "{{ extra_easyconfigs_releases[extra_easyconfigs_version]['checksum'] }}"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Extract EasyConfigs.
   ansible.builtin.unarchive:
@@ -28,4 +33,6 @@
   with_items:
     - src: "{{ easybuild_sources_dir }}/e/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}.tar.gz"
       dest: "{{ easybuild_software_dir }}/easyconfigs"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 ...

--- a/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
+++ b/roles/install_easybuild/tasks/install_easybuild_with_pip.yml
@@ -19,6 +19,8 @@
     version: "{{ easybuild_version }}"
     extra_args: "--prefix={{ easybuild_software_dir }}/EasyBuild/{{ easybuild_version }}/"
     executable: "{{ pip_path.stdout }}"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 - name: 'Determine site-packages location for Lua module file.'
   ansible.builtin.shell:
     cmd: |
@@ -31,9 +33,13 @@
     src: 'templates/EasyBuildModule.lua'
     dest: "{{ easybuild_modules_dir }}/all/EasyBuild/{{ easybuild_version }}.lua"
     mode: '0664'
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 - name: 'Create symlink for EasyBuild in "tools" modules category.'
   ansible.builtin.file:  # noqa risky-file-permissions
     src: "{{ easybuild_modules_dir }}/all/EasyBuild/{{ easybuild_version }}.lua"
     dest: "{{ easybuild_modules_dir }}/tools/EasyBuild/{{ easybuild_version }}.lua"
     state: link
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 ...

--- a/roles/install_easybuild/tasks/install_lmod.yml
+++ b/roles/install_easybuild/tasks/install_lmod.yml
@@ -8,6 +8,8 @@
     dest: "{{ easybuild_sources_dir }}/l/Lmod/{{ lmod_version }}.tar.gz"
     checksum: "{{ lmod_releases[lmod_version]['checksum'] }}"
     mode: "{{ MODE_0664_HARD }}"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Decompress Lmod.
   ansible.builtin.unarchive:
@@ -15,6 +17,8 @@
     dest: "{{ easybuild_sources_dir }}/l/Lmod/"
     copy: false
     mode: "{{ MODE__775_SOFT }}"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Compile and install Lmod.
   ansible.builtin.shell:
@@ -28,4 +32,6 @@
                      --with-caseIndependentSorting=YES \
              && make install
   changed_when: true
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 ...

--- a/roles/install_easybuild/tasks/install_lua.yml
+++ b/roles/install_easybuild/tasks/install_lua.yml
@@ -10,6 +10,8 @@
     checksum: "{{ lua_releases[lua_version]['checksum'] }}"
     timeout: 60
     validate_certs: false  # Sourceforge redirects to https and this fails when Python on the target host is version <= 2.6.6.
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Decompress Lua.
   ansible.builtin.unarchive:
@@ -17,6 +19,8 @@
     dest: "{{ easybuild_sources_dir }}/l/Lua/"
     copy: false
     mode: "{{ MODE__775_SOFT }}"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 - name: Compile and install Lua.
   ansible.builtin.shell:
@@ -27,4 +31,6 @@
                      --prefix={{ easybuild_software_dir }}/Lua/{{ lua_version }} \
              && make install
   changed_when: true
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 ...

--- a/roles/install_easybuild/tasks/main.yml
+++ b/roles/install_easybuild/tasks/main.yml
@@ -14,6 +14,8 @@
     - "{{ easybuild_modules_dir }}/tools/EasyBuild"
     - "{{ easybuild_modules_dir }}/.lmod"
     - "{{ hpc_env_prefix }}/.tmp"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 
 #
 # Update environment.
@@ -28,6 +30,8 @@
       dest: '.lmod/lmodrc.lua'
     - src: 'modules.bashrc'
       dest: 'modules.bashrc'
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 - name: Insert/update block into ~/.bashrc to make sure modules.bashrc will be sourced.
   ansible.builtin.blockinfile:
     dest: "{{ ansible_env.HOME }}/.bashrc"
@@ -39,7 +43,6 @@
     insertafter: EOF
     create: true
     mode: '0600'
-
 #
 # Lua.
 #

--- a/roles/install_modules_with_easybuild/tasks/main.yml
+++ b/roles/install_modules_with_easybuild/tasks/main.yml
@@ -27,4 +27,6 @@
   with_items: "{{ easyconfigs }}"
   register: eb_status
   changed_when: "'is already installed' not in eb_status.stdout"
+  become: "{% if eb_user is defined and eb_user | length > 0 %}true{% else %}false{% endif %}"
+  become_user: "{{ eb_user | default(omit) }}"
 ...


### PR DESCRIPTION
* Added checksum for `take-it-easyconfigs` 1.3.
* Added missing `concordance/samplesheets/archive` folder for ConcordanceCheck.
* Added functionality to optionally deploy EB and modules with a specific user, which is required for deployment on all-in-one Slurm boxes.
* Upgraded `easybuild_version` to 4.8.0 and `extra_easyconfigs_version` to 1.3 for various clusters.
* Increased time-out for fetching source code from Github from default 10 seconds to 30 seconds, because Github appears to be bit slower due to HTTP 302 redirects, which can cause failures with the default timeout.