### PR TITLE
Implemented functionality to use a different NGS_Automated version for "bundles" of NGS_Automated.

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -506,8 +506,9 @@ group_module_versions:
     NGS_DNA: 4.2.2
     ngs-utils: 24.03.1
   umcg-atd:
-    NGS_Automated: 4.3.1
+    NGS_Automated: 4.3.1  # Default NGS_Automated version.
     NGS_DNA: 4.2.2
+      NGS_Automated: beta  # Overruling NGS_Automated version for NGS_Automated-NGS_DNA bundles.
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.02.2
     NGS_Demultiplexing: 2.5.4
@@ -564,14 +565,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-NGS_Demultiplexing-{{ group_module_versions['umcg-atd']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-atd']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-atd"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-atd -p NGS_Demultiplexing"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
@@ -585,7 +586,7 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
          startPipeline.sh -g umcg-atd -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
@@ -807,14 +808,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-gd"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
@@ -828,7 +829,7 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
          startPipeline.sh -g umcg-gd -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
@@ -1037,14 +1038,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['AGCT']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
          arrayConversion.sh -g umcg-gsad"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
@@ -1065,7 +1066,7 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
          startPipeline.sh -g umcg-gsad -p GAP"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
@@ -1117,14 +1118,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['AGCT']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
          arrayConversion.sh -g umcg-gap"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
@@ -1145,7 +1146,7 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
          startPipeline.sh -g umcg-gap -p GAP"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
@@ -1218,21 +1219,21 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
          startDragenPipeline.sh -g umcg-gst"
   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['nf_ngs_dna']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
          startNextflowDragenPipeline.sh -g umcg-gst"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
          startPipeline.sh -g umcg-gst -p NGS_RNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
@@ -1284,21 +1285,21 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
          startDragenPipeline.sh -g umcg-genomescan"
   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['nf_ngs_dna']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
          startNextflowDragenPipeline.sh -g umcg-genomescan"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
          startPipeline.sh -g umcg-genomescan -p NGS_RNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
@@ -1343,7 +1344,7 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated'] }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-labgnkbh"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-labgnkbh-dm

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -489,18 +489,21 @@ group_notification_targets:
 #
 group_module_versions:
   umcg-gd:
-    NGS_Automated: 4.3.1
+    NGS_Automated:
+      default: 4.3.1
     NGS_DNA: 4.2.2
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.03.1
     NGS_Demultiplexing: 2.5.4
   umcg-gap:
-    NGS_Automated: 4.3.1
+    NGS_Automated:
+      default: 4.3.1
     GAP: 2.7.0
     AGCT: 1.3.0
     ngs-utils: 24.03.1
   umcg-genomescan:
-    NGS_Automated: 4.3.1
+    NGS_Automated:
+      default: 4.3.1
     nf_ngs_dna: 1.1.0
     NGS_RNA: 4.1.2
     NGS_DNA: 4.2.2
@@ -514,28 +517,34 @@ group_module_versions:
     ngs-utils: 24.02.2
     NGS_Demultiplexing: 2.5.4
   umcg-gsad:
-    NGS_Automated: 4.3.1
+    NGS_Automated:
+      default: 4.3.1
     GAP: 2.7.0
     AGCT: 1.3.0
     ngs-utils: 24.03.1
   umcg-gst:
-    NGS_Automated: 4.3.1
+    NGS_Automated:
+      default: 4.3.1
     nf_ngs_dna: 1.1.0
     NGS_DNA: 4.2.2
     NGS_RNA: 4.1.2
     ngs-utils: 24.03.1
   umcg-labgnkbh:
-    NGS_Automated: 4.2.0
+    NGS_Automated:
+      default: 4.2.0
     ngs-utils: 24.03.1
     NGS_Demultiplexing: 2.5.4
   umcg-patho:
-    NGS_Automated: 4.2.0
+    NGS_Automated:
+      default: 4.2.0
     ngs-utils: 24.03.1
   # umcg-pr:
-  #   NGS_Automated: 4.1.0
+  #   NGS_Automated:
+  #     default: 4.1.0
   #   ngs-utils: 24.02.2
   umcg-lab:
-    NGS_Automated: 4.3.0
+    NGS_Automated:
+      default: 4.3.0
 crontabs:
   ######################################################################################################################
   # umcg-atd group
@@ -780,611 +789,611 @@ crontabs:
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p nanopore"
-#   ######################################################################################################################
-#   # umcg-gd group
-#   ######################################################################################################################
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gd -c"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gd -c"
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-gd"
-#   - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
-#          demultiplexing.sh -g umcg-gd"
-#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-#          splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
-#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToTmp.sh -g umcg-gd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-#          startPipeline.sh -g umcg-gd -p NGS_DNA"
-#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gd -p NGS_DNA"
-#   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToPrm.sh -g umcg-gd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-#   - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToPrm.sh -a -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
-#          copySamplesheetsForBatchToPrm.sh -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07"
-#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA"
-#   - name: NGS_Automated_copyProjectDataToPrm_RNA  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA"
-#   - name: NGS_Automated_copyProjectDataToPrm_external  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA -r /groups/umcg-genomescan/tmp07"
-#   - name: NGS_Automated_copyProjectDataToPrm_RNA_external  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA -r /groups/umcg-genomescan/tmp07"
-#   - name: benikdown  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          ${HOME}/benikdown.sh"
-#   - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-#     minute: 0
-#     hour: 6
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          ${HOME}/FileSystemCheckGD.sh"
-#   - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     # ToDo: improve job with "module load" and remove "sh"
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          cleanupDataOnTmp.sh -g umcg-gd -p NGS_DNA"
-#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     # ToDo: improve job with "module load" and remove "sh"
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          cleanupSamplesheets.sh -g umcg-gd"
-#   ##### Trendanalysis #####
-#   - name: NGS_Automated_copyQCDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     weekday: '0'
-#     minute: '0'
-#     hour: '6'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyQCDataToTmp.sh -g umcg-gd"
-#   - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     weekday: '0'
-#     minute: '0'
-#     hour: '12'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          trendAnalyse.sh -g umcg-gd"
-#   - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     weekday: '0'
-#     minute: '0'
-#     hour: '18'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyTrendAnalysisDataToPrm.sh -g umcg-gd"
-#   - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_DNA/{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-#          GavinSA.sh -g umcg-gd -t tmp07"
-#   ##### ConcordanceCheck ##### 
-#   - name: ConcordanceCheck_ParseDarwinSamplesheet  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
-#          ParseDarwinSamplesheet.sh -g umcg-gd -a umcg-gap"
-#   - name: ConcordanceCheck_ConcordanceCheck  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-#          ConcordanceCheck.sh -g umcg-gd"
-#   - name: ConcordanceCheck_copyConcordanceCheckData  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
-#          copyConcordanceCheckData.sh -g umcg-gd"
-#   - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-#          cleanup.sh -g umcg-gd"
-#   - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-#          cleanup.sh -g umcg-gd"
-#   ##### Nanopore ##### 
-#   - name: NGS_Automated_copyRawNanoporeDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyRawNanoporeDataToPrm.sh -g umcg-gd -r 145.39.79.24"
-#   - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyRawNanoporeDataToTmp.sh -g umcg-gd"
-#   - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          startNanoporePipeline.sh -g umcg-gd"
-#   - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     # ToDo: improve job with "module load" and remove "sh"
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          cleanupDataOnTmp.sh -g umcg-gd -p nanopore"
-#   - name: NGS_Automated_nanoporeCalculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gd -p nanopore"
-#   - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gd-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gd -p nanopore"
-#   ######################################################################################################################
-#   # umcg-gsad group
-#   ######################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-gsad"
-#   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
-#          arrayConversion.sh -g umcg-gsad"
-#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
-#          splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
-#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToTmp.sh -g umcg-gsad -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-#   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToPrm.sh -g umcg-gsad -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
-#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
-#          startPipeline.sh -g umcg-gsad -p GAP"
-#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gsad -p GAP"
-#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gsad -p GAP"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gsad -c"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gsad -c"
-#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gsad-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     # ToDo: improve job with "module load" and remove "sh"
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          cleanupSamplesheets.sh -g umcg-gsad"
-#   ######################################################################################################################
-#   # umcg-gap group
-#   ######################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-gap"
-#   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
-#          arrayConversion.sh -g umcg-gap"
-#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
-#          splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
-#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToTmp.sh -g umcg-gap -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-#   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToPrm.sh -g umcg-gap -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
-#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
-#          startPipeline.sh -g umcg-gap -p GAP"
-#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gap -p GAP"
-#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          copyProjectDataToPrm.sh -g umcg-gap -p GAP"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gap -c"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gap -c"
-#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gap-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     # ToDo: improve job with "module load" and remove "sh"
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          cleanupSamplesheets.sh -g umcg-gap"
-#   ######################################################################################################################
-#   # umcg-gst group
-#   ######################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-gst"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-gst -c"
-#   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          PullAndProcessGsRawData.sh -g umcg-gst"
-#   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          PullAndProcessGsAnalysisData.sh -g umcg-gst"
-#   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
-#          startDragenPipeline.sh -g umcg-gst"
-#   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
-#          startNextflowDragenPipeline.sh -g umcg-gst"
-#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
-#          startPipeline.sh -g umcg-gst -p NGS_RNA"
-#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gst -p NGS_DNA"
-#   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-gst-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-gst -p NGS_RNA"
-#   ######################################################################################################################
-#   # umcg-genomescan group
-#   ######################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-genomescan"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-genomescan -c"
-#   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          PullAndProcessGsRawData.sh -g umcg-genomescan"
-#   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          PullAndProcessGsAnalysisData.sh -g umcg-genomescan"
-#   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
-#          startDragenPipeline.sh -g umcg-genomescan"
-#   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
-#          startNextflowDragenPipeline.sh -g umcg-genomescan"
-#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
-#          startPipeline.sh -g umcg-genomescan -p NGS_RNA"
-#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_DNA"
-#   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_RNA"
-#   - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_DNA"
-#   - name: NGS_Automated_cleanupDataOnTmp_RNA  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-genomescan-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-#          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_RNA"
-#   #####################################################################################################################
-#   # umcg-labgnkbh group
-#   #####################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-labgnkbh-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-labgnkbh -d dat47"
-#   - name: NGS_Demultiplexing_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-labgnkbh-ateambot
-#     machines: "{{ groups['user_interface'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
-#          demultiplexing.sh -g umcg-labgnkbh"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-labgnkbh-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-labgnkbh -c -d dat47 -p prm47"
-#   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-labgnkbh-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-#          copyRawDataToPrm.sh -a -g umcg-labgnkbh -p NGS_Demultiplexing -m prm47 -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-#   ######################################################################################################################
-#   # umcg-patho group
-#   ######################################################################################################################
-#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-patho-ateambot
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/5'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-#          moveAndCheckSamplesheets.sh -g umcg-patho -d dat37"
-#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-patho-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-#          notifications.sh -g umcg-patho -c -d dat37 -p prm37"
-#   - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-#     user: umcg-patho-dm
-#     machines: "{{ groups['chaperone'] | default([]) }}"
-#     minute: '*/10'
-#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-#          copyBclDataToPrm.sh -g umcg-patho -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm37"
+  ######################################################################################################################
+  # umcg-gd group
+  ######################################################################################################################
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gd -c"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gd -c"
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-gd"
+  - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
+         demultiplexing.sh -g umcg-gd"
+  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
+  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToTmp.sh -g umcg-gd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         startPipeline.sh -g umcg-gd -p NGS_DNA"
+  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gd -p NGS_DNA"
+  - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToPrm.sh -g umcg-gd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+  - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToPrm.sh -a -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
+         copySamplesheetsForBatchToPrm.sh -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07"
+  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA"
+  - name: NGS_Automated_copyProjectDataToPrm_RNA  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA"
+  - name: NGS_Automated_copyProjectDataToPrm_external  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA -r /groups/umcg-genomescan/tmp07"
+  - name: NGS_Automated_copyProjectDataToPrm_RNA_external  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA -r /groups/umcg-genomescan/tmp07"
+  - name: benikdown  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         ${HOME}/benikdown.sh"
+  - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+    minute: 0
+    hour: 6
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         ${HOME}/FileSystemCheckGD.sh"
+  - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    # ToDo: improve job with "module load" and remove "sh"
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         cleanupDataOnTmp.sh -g umcg-gd -p NGS_DNA"
+  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    # ToDo: improve job with "module load" and remove "sh"
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         cleanupSamplesheets.sh -g umcg-gd"
+  ##### Trendanalysis #####
+  - name: NGS_Automated_copyQCDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    weekday: '0'
+    minute: '0'
+    hour: '6'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyQCDataToTmp.sh -g umcg-gd"
+  - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    weekday: '0'
+    minute: '0'
+    hour: '12'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         trendAnalyse.sh -g umcg-gd"
+  - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    weekday: '0'
+    minute: '0'
+    hour: '18'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyTrendAnalysisDataToPrm.sh -g umcg-gd"
+  - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_DNA/{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         GavinSA.sh -g umcg-gd -t tmp07"
+  ##### ConcordanceCheck ##### 
+  - name: ConcordanceCheck_ParseDarwinSamplesheet  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
+         ParseDarwinSamplesheet.sh -g umcg-gd -a umcg-gap"
+  - name: ConcordanceCheck_ConcordanceCheck  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+         ConcordanceCheck.sh -g umcg-gd"
+  - name: ConcordanceCheck_copyConcordanceCheckData  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
+         copyConcordanceCheckData.sh -g umcg-gd"
+  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+         cleanup.sh -g umcg-gd"
+  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+         cleanup.sh -g umcg-gd"
+  ##### Nanopore ##### 
+  - name: NGS_Automated_copyRawNanoporeDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyRawNanoporeDataToPrm.sh -g umcg-gd -r 145.39.79.24"
+  - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyRawNanoporeDataToTmp.sh -g umcg-gd"
+  - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         startNanoporePipeline.sh -g umcg-gd"
+  - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    # ToDo: improve job with "module load" and remove "sh"
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         cleanupDataOnTmp.sh -g umcg-gd -p nanopore"
+  - name: NGS_Automated_nanoporeCalculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gd -p nanopore"
+  - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gd-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gd -p nanopore"
+  ######################################################################################################################
+  # umcg-gsad group
+  ######################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-gsad"
+  - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
+         arrayConversion.sh -g umcg-gsad"
+  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
+  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToTmp.sh -g umcg-gsad -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+  - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToPrm.sh -g umcg-gsad -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
+  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         startPipeline.sh -g umcg-gsad -p GAP"
+  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gsad -p GAP"
+  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gsad -p GAP"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gsad -c"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gsad -c"
+  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gsad-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    # ToDo: improve job with "module load" and remove "sh"
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         cleanupSamplesheets.sh -g umcg-gsad"
+  ######################################################################################################################
+  # umcg-gap group
+  ######################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-gap"
+  - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
+         arrayConversion.sh -g umcg-gap"
+  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
+  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToTmp.sh -g umcg-gap -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+  - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToPrm.sh -g umcg-gap -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
+  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         startPipeline.sh -g umcg-gap -p GAP"
+  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gap -p GAP"
+  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         copyProjectDataToPrm.sh -g umcg-gap -p GAP"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gap -c"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gap -c"
+  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gap-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    # ToDo: improve job with "module load" and remove "sh"
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         cleanupSamplesheets.sh -g umcg-gap"
+  ######################################################################################################################
+  # umcg-gst group
+  ######################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-gst"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-gst -c"
+  - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         PullAndProcessGsRawData.sh -g umcg-gst"
+  - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         PullAndProcessGsAnalysisData.sh -g umcg-gst"
+  - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
+         startDragenPipeline.sh -g umcg-gst"
+  - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
+         startNextflowDragenPipeline.sh -g umcg-gst"
+  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
+         startPipeline.sh -g umcg-gst -p NGS_RNA"
+  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gst -p NGS_DNA"
+  - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-gst-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-gst -p NGS_RNA"
+  ######################################################################################################################
+  # umcg-genomescan group
+  ######################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-genomescan"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-genomescan -c"
+  - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         PullAndProcessGsRawData.sh -g umcg-genomescan"
+  - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         PullAndProcessGsAnalysisData.sh -g umcg-genomescan"
+  - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
+         startDragenPipeline.sh -g umcg-genomescan"
+  - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
+         startNextflowDragenPipeline.sh -g umcg-genomescan"
+  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
+         startPipeline.sh -g umcg-genomescan -p NGS_RNA"
+  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-genomescan -p NGS_DNA"
+  - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         calculateProjectMd5s.sh -g umcg-genomescan -p NGS_RNA"
+  - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_DNA"
+  - name: NGS_Automated_cleanupDataOnTmp_RNA  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-genomescan-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+         cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_RNA"
+  #####################################################################################################################
+  # umcg-labgnkbh group
+  #####################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-labgnkbh-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-labgnkbh -d dat47"
+  - name: NGS_Demultiplexing_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-labgnkbh-ateambot
+    machines: "{{ groups['user_interface'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
+         demultiplexing.sh -g umcg-labgnkbh"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-labgnkbh-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-labgnkbh -c -d dat47 -p prm47"
+  - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-labgnkbh-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+         copyRawDataToPrm.sh -a -g umcg-labgnkbh -p NGS_Demultiplexing -m prm47 -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+  ######################################################################################################################
+  # umcg-patho group
+  ######################################################################################################################
+  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-patho-ateambot
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/5'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+         moveAndCheckSamplesheets.sh -g umcg-patho -d dat37"
+  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-patho-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+         notifications.sh -g umcg-patho -c -d dat37 -p prm37"
+  - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+    user: umcg-patho-dm
+    machines: "{{ groups['chaperone'] | default([]) }}"
+    minute: '*/10'
+    job: /bin/bash -c "{{ configure_env_in_cronjob }};
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+         copyBclDataToPrm.sh -g umcg-patho -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm37"
   ######################################################################################################################
   # umcg-pr group
   ######################################################################################################################

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -506,9 +506,10 @@ group_module_versions:
     NGS_DNA: 4.2.2
     ngs-utils: 24.03.1
   umcg-atd:
-    NGS_Automated: 4.3.1  # Default NGS_Automated version.
+    NGS_Automated:
+      default: 4.3.1  # Default NGS_Automated version.
+      NGS_DNA: beta  # Overruling NGS_Automated version for NGS_Automated-NGS_DNA bundles.
     NGS_DNA: 4.2.2
-      NGS_Automated: beta  # Overruling NGS_Automated version for NGS_Automated-NGS_DNA bundles.
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.02.2
     NGS_Demultiplexing: 2.5.4
@@ -544,70 +545,70 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-atd -c"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-atd -c"
   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-atd"
   - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-atd']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-atd']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-atd"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-atd -p NGS_Demultiplexing"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToTmp.sh -g umcg-atd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-atd']['NGS_DNA'] }};
          startPipeline.sh -g umcg-atd -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-atd -p NGS_DNA"
   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -g umcg-atd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -a -g umcg-atd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-gst/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
          copySamplesheetsForBatchToPrm.sh -g umcg-atd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-gst/tmp07"
   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
@@ -615,21 +616,21 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_DNA"
   - name: NGS_Automated_copyProjectDataToPrm_external_DNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_DNA -r /groups/umcg-gst/tmp07"
   - name: NGS_Automated_copyProjectDataToPrm_external_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-atd']['NGS_Automated']['default']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_RNA -r /groups/umcg-gst/tmp07"
   - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
@@ -652,7 +653,7 @@ crontabs:
     minute: '0'
     hour: '6'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyQCDataToTmp.sh -g umcg-atd"
   - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
@@ -661,7 +662,7 @@ crontabs:
     minute: '0'
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          trendAnalyse.sh -g umcg-atd"
   - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
@@ -670,7 +671,7 @@ crontabs:
     minute: '0'
     hour: '18'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyTrendAnalysisDataToPrm.sh -g umcg-atd"
   - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
@@ -735,28 +736,28 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawNanoporeDataToPrm.sh -g umcg-atd -r 10.73.57.10"
   - name: NGS_Automated_copyRawNanoporeDataToPrm_11  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawNanoporeDataToPrm.sh -g umcg-atd -r 10.73.57.11"
   - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyRawNanoporeDataToTmp.sh -g umcg-atd"
   - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          startNanoporePipeline.sh -g umcg-atd"
   - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot
@@ -770,14 +771,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-atd -p nanopore"
   - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p nanopore"
   ######################################################################################################################
   # umcg-gd group
@@ -787,70 +788,70 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gd -c"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gd -c"
   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-gd"
   - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-gd"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToTmp.sh -g umcg-gd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gd']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
          startPipeline.sh -g umcg-gd -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gd -p NGS_DNA"
   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -g umcg-gd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -a -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
          copySamplesheetsForBatchToPrm.sh -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07"
   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
@@ -858,28 +859,28 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA"
   - name: NGS_Automated_copyProjectDataToPrm_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA"
   - name: NGS_Automated_copyProjectDataToPrm_external  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA -r /groups/umcg-genomescan/tmp07"
   - name: NGS_Automated_copyProjectDataToPrm_RNA_external  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA -r /groups/umcg-genomescan/tmp07"
   - name: benikdown  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
@@ -900,7 +901,7 @@ crontabs:
     minute: '*/10'
     # ToDo: improve job with "module load" and remove "sh"
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          cleanupDataOnTmp.sh -g umcg-gd -p NGS_DNA"
   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
@@ -917,7 +918,7 @@ crontabs:
     minute: '0'
     hour: '6'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyQCDataToTmp.sh -g umcg-gd"
   - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
@@ -926,7 +927,7 @@ crontabs:
     minute: '0'
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          trendAnalyse.sh -g umcg-gd"
   - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
@@ -935,7 +936,7 @@ crontabs:
     minute: '0'
     hour: '18'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyTrendAnalysisDataToPrm.sh -g umcg-gd"
   - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
@@ -986,21 +987,21 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyRawNanoporeDataToPrm.sh -g umcg-gd -r 145.39.79.24"
   - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyRawNanoporeDataToTmp.sh -g umcg-gd"
   - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          startNanoporePipeline.sh -g umcg-gd"
   - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-ateambot
@@ -1014,14 +1015,14 @@ crontabs:
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gd -p nanopore"
   - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gd -p nanopore"
   ######################################################################################################################
   # umcg-gsad group
@@ -1031,70 +1032,70 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-gsad"
   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['AGCT']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
          arrayConversion.sh -g umcg-gsad"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          copyRawDataToTmp.sh -g umcg-gsad -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -g umcg-gsad -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gsad']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
          startPipeline.sh -g umcg-gsad -p GAP"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gsad -p GAP"
   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gsad -p GAP"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gsad -c"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gsad -c"
   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gsad-dm
@@ -1111,70 +1112,70 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-gap"
   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['AGCT']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
          arrayConversion.sh -g umcg-gap"
   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
          splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          copyRawDataToTmp.sh -g umcg-gap -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -g umcg-gap -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['GAP']['NGS_Automated'] | default(group_module_versions['umcg-gap']['NGS_Automated']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
          startPipeline.sh -g umcg-gap -p GAP"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gap -p GAP"
   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-gap -p GAP"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gap -c"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gap -c"
   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gap-dm
@@ -1191,63 +1192,63 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-gst"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-gst -c"
   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          PullAndProcessGsRawData.sh -g umcg-gst"
   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          PullAndProcessGsAnalysisData.sh -g umcg-gst"
   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
          startDragenPipeline.sh -g umcg-gst"
   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['nf_ngs_dna']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
          startNextflowDragenPipeline.sh -g umcg-gst"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-gst']['NGS_Automated']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
          startPipeline.sh -g umcg-gst -p NGS_RNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gst -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gst-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-gst -p NGS_RNA"
   ######################################################################################################################
   # umcg-genomescan group
@@ -1257,77 +1258,77 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-genomescan"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-genomescan -c"
   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          PullAndProcessGsRawData.sh -g umcg-genomescan"
   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          PullAndProcessGsAnalysisData.sh -g umcg-genomescan"
   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
          startDragenPipeline.sh -g umcg-genomescan"
   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['nf_ngs_dna']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
          startNextflowDragenPipeline.sh -g umcg-genomescan"
   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
          startPipeline.sh -g umcg-genomescan -p NGS_RNA"
   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_DNA"
   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_RNA"
   - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_DNA"
   - name: NGS_Automated_cleanupDataOnTmp_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-genomescan-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_RNA"
   #####################################################################################################################
   # umcg-labgnkbh group
@@ -1337,28 +1338,28 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-labgnkbh -d dat47"
   - name: NGS_Demultiplexing_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-labgnkbh-ateambot
     machines: "{{ groups['user_interface'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing']['NGS_Automated'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
          demultiplexing.sh -g umcg-labgnkbh"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-labgnkbh-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-labgnkbh -c -d dat47 -p prm47"
   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-labgnkbh-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
          copyRawDataToPrm.sh -a -g umcg-labgnkbh -p NGS_Demultiplexing -m prm47 -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
   ######################################################################################################################
   # umcg-patho group
@@ -1368,21 +1369,21 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/5'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
          moveAndCheckSamplesheets.sh -g umcg-patho -d dat37"
   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-patho-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
          notifications.sh -g umcg-patho -c -d dat37 -p prm37"
   - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-patho-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
          copyBclDataToPrm.sh -g umcg-patho -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm37"
   ######################################################################################################################
   # umcg-pr group
@@ -1392,21 +1393,21 @@ crontabs:
   #   machines: "{{ groups['chaperone'] | default([]) }}"
   #   minute: '*/5'
   #   job: /bin/bash -c "{{ configure_env_in_cronjob }};
-  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated'] }}-bare;
+  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated']['default'] }}-bare;
   #        moveAndCheckSamplesheets.sh -g umcg-pr -d dat57"
   # - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
   #   user: umcg-pr-dm
   #   machines: "{{ groups['chaperone'] | default([]) }}"
   #   minute: '*/10'
   #   job: /bin/bash -c "{{ configure_env_in_cronjob }};
-  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated'] }}-bare;
+  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated']['default'] }}-bare;
   #        notifications.sh -g umcg-pr -c -d dat57 -p prm57"
   # - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
   #   user: umcg-pr-dm
   #   machines: "{{ groups['chaperone'] | default([]) }}"
   #   minute: '*/10'
   #   job: /bin/bash -c "{{ configure_env_in_cronjob }};
-  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated'] }}-bare;
+  #        module load NGS_Automated/{{ group_module_versions['umcg-pr']['NGS_Automated']['default'] }}-bare;
   #        copyBclDataToPrm.sh -g umcg-pr -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm57"
   ######################################################################################################################
   # umcg-lab group
@@ -1416,7 +1417,7 @@ crontabs:
   #  machines: "{{ groups['user_interface'] | default([]) }}"
   #  minute: '*/10'
   #  job: /bin/bash -c "{{ configure_env_in_cronjob }};
-  #       module load NGS_Automated/{{ group_module_versions['umcg-lab']['NGS_Automated'] }}-bare;
+  #       module load NGS_Automated/{{ group_module_versions['umcg-lab']['NGS_Automated']['default'] }}-bare;
   #       moveSequencingData.sh -t tmp07"
 
 #

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -780,611 +780,611 @@ crontabs:
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated']['default'] }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p nanopore"
-  ######################################################################################################################
-  # umcg-gd group
-  ######################################################################################################################
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gd -c"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gd -c"
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-gd"
-  - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
-         demultiplexing.sh -g umcg-gd"
-  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-         splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
-  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToTmp.sh -g umcg-gd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-         startPipeline.sh -g umcg-gd -p NGS_DNA"
-  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gd -p NGS_DNA"
-  - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToPrm.sh -g umcg-gd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-  - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToPrm.sh -a -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
-         copySamplesheetsForBatchToPrm.sh -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07"
-  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA"
-  - name: NGS_Automated_copyProjectDataToPrm_RNA  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA"
-  - name: NGS_Automated_copyProjectDataToPrm_external  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA -r /groups/umcg-genomescan/tmp07"
-  - name: NGS_Automated_copyProjectDataToPrm_RNA_external  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA -r /groups/umcg-genomescan/tmp07"
-  - name: benikdown  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         ${HOME}/benikdown.sh"
-  - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-    minute: 0
-    hour: 6
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         ${HOME}/FileSystemCheckGD.sh"
-  - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    # ToDo: improve job with "module load" and remove "sh"
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         cleanupDataOnTmp.sh -g umcg-gd -p NGS_DNA"
-  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    # ToDo: improve job with "module load" and remove "sh"
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         cleanupSamplesheets.sh -g umcg-gd"
-  ##### Trendanalysis #####
-  - name: NGS_Automated_copyQCDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    weekday: '0'
-    minute: '0'
-    hour: '6'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyQCDataToTmp.sh -g umcg-gd"
-  - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    weekday: '0'
-    minute: '0'
-    hour: '12'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         trendAnalyse.sh -g umcg-gd"
-  - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    weekday: '0'
-    minute: '0'
-    hour: '18'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyTrendAnalysisDataToPrm.sh -g umcg-gd"
-  - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_DNA/{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
-         GavinSA.sh -g umcg-gd -t tmp07"
-  ##### ConcordanceCheck ##### 
-  - name: ConcordanceCheck_ParseDarwinSamplesheet  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
-         ParseDarwinSamplesheet.sh -g umcg-gd -a umcg-gap"
-  - name: ConcordanceCheck_ConcordanceCheck  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-         ConcordanceCheck.sh -g umcg-gd"
-  - name: ConcordanceCheck_copyConcordanceCheckData  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
-         copyConcordanceCheckData.sh -g umcg-gd"
-  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-         cleanup.sh -g umcg-gd"
-  - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
-         cleanup.sh -g umcg-gd"
-  ##### Nanopore ##### 
-  - name: NGS_Automated_copyRawNanoporeDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyRawNanoporeDataToPrm.sh -g umcg-gd -r 145.39.79.24"
-  - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyRawNanoporeDataToTmp.sh -g umcg-gd"
-  - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         startNanoporePipeline.sh -g umcg-gd"
-  - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    # ToDo: improve job with "module load" and remove "sh"
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         cleanupDataOnTmp.sh -g umcg-gd -p nanopore"
-  - name: NGS_Automated_nanoporeCalculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gd -p nanopore"
-  - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gd-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gd -p nanopore"
-  ######################################################################################################################
-  # umcg-gsad group
-  ######################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-gsad"
-  - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
-         arrayConversion.sh -g umcg-gsad"
-  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
-         splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
-  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToTmp.sh -g umcg-gsad -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-  - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToPrm.sh -g umcg-gsad -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
-  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
-         startPipeline.sh -g umcg-gsad -p GAP"
-  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gsad -p GAP"
-  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gsad -p GAP"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gsad -c"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gsad -c"
-  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gsad-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    # ToDo: improve job with "module load" and remove "sh"
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         cleanupSamplesheets.sh -g umcg-gsad"
-  ######################################################################################################################
-  # umcg-gap group
-  ######################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-gap"
-  - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
-         arrayConversion.sh -g umcg-gap"
-  - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
-         splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
-  - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToTmp.sh -g umcg-gap -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-  - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToPrm.sh -g umcg-gap -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
-  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
-         startPipeline.sh -g umcg-gap -p GAP"
-  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gap -p GAP"
-  - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         copyProjectDataToPrm.sh -g umcg-gap -p GAP"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gap -c"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gap -c"
-  - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gap-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    # ToDo: improve job with "module load" and remove "sh"
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         cleanupSamplesheets.sh -g umcg-gap"
-  ######################################################################################################################
-  # umcg-gst group
-  ######################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-gst"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-gst -c"
-  - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         PullAndProcessGsRawData.sh -g umcg-gst"
-  - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         PullAndProcessGsAnalysisData.sh -g umcg-gst"
-  - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
-         startDragenPipeline.sh -g umcg-gst"
-  - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
-         startNextflowDragenPipeline.sh -g umcg-gst"
-  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
-         startPipeline.sh -g umcg-gst -p NGS_RNA"
-  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gst -p NGS_DNA"
-  - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-gst-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-gst -p NGS_RNA"
-  ######################################################################################################################
-  # umcg-genomescan group
-  ######################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-genomescan"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-genomescan -c"
-  - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         PullAndProcessGsRawData.sh -g umcg-genomescan"
-  - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         PullAndProcessGsAnalysisData.sh -g umcg-genomescan"
-  - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
-         startDragenPipeline.sh -g umcg-genomescan"
-  - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
-         startNextflowDragenPipeline.sh -g umcg-genomescan"
-  - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
-         startPipeline.sh -g umcg-genomescan -p NGS_RNA"
-  - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-genomescan -p NGS_DNA"
-  - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         calculateProjectMd5s.sh -g umcg-genomescan -p NGS_RNA"
-  - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_DNA"
-  - name: NGS_Automated_cleanupDataOnTmp_RNA  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-genomescan-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
-         cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_RNA"
-  #####################################################################################################################
-  # umcg-labgnkbh group
-  #####################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-labgnkbh-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-labgnkbh -d dat47"
-  - name: NGS_Demultiplexing_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-labgnkbh-ateambot
-    machines: "{{ groups['user_interface'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
-         demultiplexing.sh -g umcg-labgnkbh"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-labgnkbh-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-labgnkbh -c -d dat47 -p prm47"
-  - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-labgnkbh-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
-         copyRawDataToPrm.sh -a -g umcg-labgnkbh -p NGS_Demultiplexing -m prm47 -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
-  ######################################################################################################################
-  # umcg-patho group
-  ######################################################################################################################
-  - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-patho-ateambot
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/5'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-         moveAndCheckSamplesheets.sh -g umcg-patho -d dat37"
-  - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-patho-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-         notifications.sh -g umcg-patho -c -d dat37 -p prm37"
-  - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
-    user: umcg-patho-dm
-    machines: "{{ groups['chaperone'] | default([]) }}"
-    minute: '*/10'
-    job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
-         copyBclDataToPrm.sh -g umcg-patho -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm37"
+#   ######################################################################################################################
+#   # umcg-gd group
+#   ######################################################################################################################
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gd -c"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gd -c"
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-gd"
+#   - name: NGS_Automated_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-gd']['NGS_Demultiplexing'] }};
+#          demultiplexing.sh -g umcg-gd"
+#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+#          splitAndMoveSamplesheetPerProject.sh -g umcg-gd -p NGS_Demultiplexing"
+#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToTmp.sh -g umcg-gd -p NGS_DNA -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gd']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+#          startPipeline.sh -g umcg-gd -p NGS_DNA"
+#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gd -p NGS_DNA"
+#   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToPrm.sh -g umcg-gd -p NGS_Demultiplexing -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+#   - name: NGS_Automated_copyRawDataToPrm_genomescan  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToPrm.sh -a -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07 -f run01.processGsRawData.finished -p DRAGEN;
+#          copySamplesheetsForBatchToPrm.sh -g umcg-gd -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -r /groups/umcg-genomescan/tmp07"
+#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA"
+#   - name: NGS_Automated_copyProjectDataToPrm_RNA  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA"
+#   - name: NGS_Automated_copyProjectDataToPrm_external  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_DNA -r /groups/umcg-genomescan/tmp07"
+#   - name: NGS_Automated_copyProjectDataToPrm_RNA_external  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gd -p NGS_RNA -r /groups/umcg-genomescan/tmp07"
+#   - name: benikdown  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          ${HOME}/benikdown.sh"
+#   - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+#     minute: 0
+#     hour: 6
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          ${HOME}/FileSystemCheckGD.sh"
+#   - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     # ToDo: improve job with "module load" and remove "sh"
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          cleanupDataOnTmp.sh -g umcg-gd -p NGS_DNA"
+#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     # ToDo: improve job with "module load" and remove "sh"
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          cleanupSamplesheets.sh -g umcg-gd"
+#   ##### Trendanalysis #####
+#   - name: NGS_Automated_copyQCDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     weekday: '0'
+#     minute: '0'
+#     hour: '6'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyQCDataToTmp.sh -g umcg-gd"
+#   - name: NGS_Automated_trendAnalyse  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     weekday: '0'
+#     minute: '0'
+#     hour: '12'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          trendAnalyse.sh -g umcg-gd"
+#   - name: NGS_Automated_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     weekday: '0'
+#     minute: '0'
+#     hour: '18'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyTrendAnalysisDataToPrm.sh -g umcg-gd"
+#   - name: NGS_DNA_GavinSA  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_DNA/{{ group_module_versions['umcg-gd']['NGS_DNA'] }};
+#          GavinSA.sh -g umcg-gd -t tmp07"
+#   ##### ConcordanceCheck ##### 
+#   - name: ConcordanceCheck_ParseDarwinSamplesheet  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
+#          ParseDarwinSamplesheet.sh -g umcg-gd -a umcg-gap"
+#   - name: ConcordanceCheck_ConcordanceCheck  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+#          ConcordanceCheck.sh -g umcg-gd"
+#   - name: ConcordanceCheck_copyConcordanceCheckData  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }}-bare;
+#          copyConcordanceCheckData.sh -g umcg-gd"
+#   - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+#          cleanup.sh -g umcg-gd"
+#   - name: ConcordanceCheck_cleanup  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load ConcordanceCheck/{{ group_module_versions['umcg-gd']['ConcordanceCheck'] }};
+#          cleanup.sh -g umcg-gd"
+#   ##### Nanopore ##### 
+#   - name: NGS_Automated_copyRawNanoporeDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyRawNanoporeDataToPrm.sh -g umcg-gd -r 145.39.79.24"
+#   - name: NGS_Automated_copyRawNanoporeDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyRawNanoporeDataToTmp.sh -g umcg-gd"
+#   - name: NGS_Automated_startNanoporePipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          startNanoporePipeline.sh -g umcg-gd"
+#   - name: NGS_Automated_cleanupNanoporeDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     # ToDo: improve job with "module load" and remove "sh"
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          cleanupDataOnTmp.sh -g umcg-gd -p nanopore"
+#   - name: NGS_Automated_nanoporeCalculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gd -p nanopore"
+#   - name: NGS_Automated_nanoporeCopyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gd-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gd']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gd -p nanopore"
+#   ######################################################################################################################
+#   # umcg-gsad group
+#   ######################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-gsad"
+#   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gsad']['AGCT'] }};
+#          arrayConversion.sh -g umcg-gsad"
+#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+#          splitAndMoveSamplesheetPerProject.sh -g umcg-gsad -p AGCT"
+#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToTmp.sh -g umcg-gsad -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+#   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToPrm.sh -g umcg-gsad -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
+#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gsad']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gsad']['GAP'] }};
+#          startPipeline.sh -g umcg-gsad -p GAP"
+#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gsad -p GAP"
+#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gsad -p GAP"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gsad -c"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gsad']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gsad -c"
+#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gsad-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     # ToDo: improve job with "module load" and remove "sh"
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          cleanupSamplesheets.sh -g umcg-gsad"
+#   ######################################################################################################################
+#   # umcg-gap group
+#   ######################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-gap"
+#   - name: AGCT_arrayConversion  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['AGCT'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-AGCT-{{ group_module_versions['umcg-gap']['AGCT'] }};
+#          arrayConversion.sh -g umcg-gap"
+#   - name: NGS_Automated_splitAndMoveSamplesheetPerProject  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+#          splitAndMoveSamplesheetPerProject.sh -g umcg-gap -p AGCT"
+#   - name: NGS_Automated_copyRawDataToTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToTmp.sh -g umcg-gap -p GAP -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+#   - name: NGS_Automated_copyRawDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToPrm.sh -g umcg-gap -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p AGCT"
+#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['GAP'] | default(group_module_versions['umcg-gap']['NGS_Automated']['default']) }}-GAP-{{ group_module_versions['umcg-gap']['GAP'] }};
+#          startPipeline.sh -g umcg-gap -p GAP"
+#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gap -p GAP"
+#   - name: NGS_Automated_copyProjectDataToPrm  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          copyProjectDataToPrm.sh -g umcg-gap -p GAP"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gap -c"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gap']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gap -c"
+#   - name: NGS_Automated_cleanupSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gap-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     # ToDo: improve job with "module load" and remove "sh"
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          cleanupSamplesheets.sh -g umcg-gap"
+#   ######################################################################################################################
+#   # umcg-gst group
+#   ######################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-gst"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-gst -c"
+#   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          PullAndProcessGsRawData.sh -g umcg-gst"
+#   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          PullAndProcessGsAnalysisData.sh -g umcg-gst"
+#   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-gst']['NGS_DNA'] }};
+#          startDragenPipeline.sh -g umcg-gst"
+#   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-gst']['nf_ngs_dna'] }};
+#          startNextflowDragenPipeline.sh -g umcg-gst"
+#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-gst']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-gst']['NGS_RNA'] }};
+#          startPipeline.sh -g umcg-gst -p NGS_RNA"
+#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gst -p NGS_DNA"
+#   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-gst-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-gst']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-gst -p NGS_RNA"
+#   ######################################################################################################################
+#   # umcg-genomescan group
+#   ######################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-genomescan"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) + groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-genomescan -c"
+#   - name: NGS_Automated_PullAndProcessGsRawData  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          PullAndProcessGsRawData.sh -g umcg-genomescan"
+#   - name: NGS_Automated_PullAndProcessGsAnalysisData  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          PullAndProcessGsAnalysisData.sh -g umcg-genomescan"
+#   - name: NGS_Automated_startDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_DNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_DNA-{{ group_module_versions['umcg-genomescan']['NGS_DNA'] }};
+#          startDragenPipeline.sh -g umcg-genomescan"
+#   - name: NGS_Automated_startNextflowDragenPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['nf_ngs_dna'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-nf_ngs_dna-{{ group_module_versions['umcg-genomescan']['nf_ngs_dna'] }};
+#          startNextflowDragenPipeline.sh -g umcg-genomescan"
+#   - name: NGS_Automated_startPipeline  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['NGS_RNA'] | default(group_module_versions['umcg-genomescan']['NGS_Automated']['default']) }}-NGS_RNA-{{ group_module_versions['umcg-genomescan']['NGS_RNA'] }};
+#          startPipeline.sh -g umcg-genomescan -p NGS_RNA"
+#   - name: NGS_Automated_calculateProjectMd5s  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_DNA"
+#   - name: NGS_Automated_calculateProjectMd5s_RNA  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          calculateProjectMd5s.sh -g umcg-genomescan -p NGS_RNA"
+#   - name: NGS_Automated_cleanupDataOnTmp  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_DNA"
+#   - name: NGS_Automated_cleanupDataOnTmp_RNA  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-genomescan-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-genomescan']['NGS_Automated']['default'] }}-bare;
+#          cleanupDataOnTmp.sh -g umcg-genomescan -p NGS_RNA"
+#   #####################################################################################################################
+#   # umcg-labgnkbh group
+#   #####################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-labgnkbh-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-labgnkbh -d dat47"
+#   - name: NGS_Demultiplexing_demultiplexing  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-labgnkbh-ateambot
+#     machines: "{{ groups['user_interface'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['NGS_Demultiplexing'] | default(group_module_versions['umcg-labgnkbh']['NGS_Automated']['default']) }}-NGS_Demultiplexing-{{ group_module_versions['umcg-labgnkbh']['NGS_Demultiplexing'] }};
+#          demultiplexing.sh -g umcg-labgnkbh"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-labgnkbh-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-labgnkbh -c -d dat47 -p prm47"
+#   - name: NGS_Automated_copyRawDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-labgnkbh-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-labgnkbh']['NGS_Automated']['default'] }}-bare;
+#          copyRawDataToPrm.sh -a -g umcg-labgnkbh -p NGS_Demultiplexing -m prm47 -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }}"
+#   ######################################################################################################################
+#   # umcg-patho group
+#   ######################################################################################################################
+#   - name: NGS_Automated_moveAndCheckSamplesheets  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-patho-ateambot
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/5'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+#          moveAndCheckSamplesheets.sh -g umcg-patho -d dat37"
+#   - name: NGS_Automated_notifications  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-patho-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+#          notifications.sh -g umcg-patho -c -d dat37 -p prm37"
+#   - name: NGS_Automated_copyBclDataToPrm_inhouse  # Unique ID required to update existing cronjob: do not modify.
+#     user: umcg-patho-dm
+#     machines: "{{ groups['chaperone'] | default([]) }}"
+#     minute: '*/10'
+#     job: /bin/bash -c "{{ configure_env_in_cronjob }};
+#          module load NGS_Automated/{{ group_module_versions['umcg-patho']['NGS_Automated']['default'] }}-bare;
+#          copyBclDataToPrm.sh -g umcg-patho -s {{ groups['jumphost'] | first }}+{{ groups['user_interface'] | first }} -p prm37"
   ######################################################################################################################
   # umcg-pr group
   ######################################################################################################################

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -615,21 +615,21 @@ crontabs:
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_DNA"
   - name: NGS_Automated_copyProjectDataToPrm_external_DNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_DNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_DNA -r /groups/umcg-gst/tmp07"
   - name: NGS_Automated_copyProjectDataToPrm_external_RNA  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
     minute: '*/10'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
-         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_Automated'] }}-bare;
+         module load NGS_Automated/{{ group_module_versions['umcg-atd']['NGS_RNA']['NGS_Automated'] | default(group_module_versions['umcg-atd']['NGS_Automated']) }}-bare;
          copyProjectDataToPrm.sh -g umcg-atd -p NGS_RNA -r /groups/umcg-gst/tmp07"
   - name: FileSystemCheck  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-ateambot


### PR DESCRIPTION
Only for `WingedHelix`:
* Implemented functionality to use a different `NGS_Automated` version for "_**bundles**_" of `NGS_Automated` combined with other _**modules**_ as compared to the default `NGS_Automated` version used for all cronjobs of a group.
* This PR also uses this functionality to change the `NGS_Automated` version from the default `4.3.1` to`beta` for the bundle combining `NGS_Automated` with `NGS_DNA` for the `umcg-atd` group.

`group_vars` for other stacks can be updated in the same way to provide the same functionality.