### PR TITLE
Updated take-it-easyconfigs repo version for new cluster-utils v25.01.2

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -18,7 +18,7 @@ lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.8.0'
 eb_user: umcg-envsync
-extra_easyconfigs_version: 24.03.2
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 # extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #
@@ -1318,7 +1318,7 @@ refdata: [
 #  'snpEff-4.3',
 ]
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v23.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v23.04.1.eb'
 chaperone_only_easyconfigs: "{{ all_easyconfigs | select('search', '(NGS_Automated-.*-bare|depad-utils-.*).eb') | list }}"
 ...

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -18,7 +18,7 @@ lua_version: '5.1.4.9'
 lmod_version: '8.6.2'
 easybuild_version: '4.8.0'
 eb_user: umcg-envsync
-extra_easyconfigs_version: 24.03.2
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 # extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #
@@ -1315,7 +1315,7 @@ refdata: [
 #  'snpEff-4.3',
 ]
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v23.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v23.04.1.eb'
 chaperone_only_easyconfigs: "{{ all_easyconfigs | select('search', '(NGS_Automated-.*-bare|depad-utils-.*).eb') | list }}"
 ...

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'fd'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.9.1'
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -46,6 +46,6 @@ public_sources: [
 private_sources: []
 refdata: []
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 ...

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'gs'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.9.1'
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -58,6 +58,6 @@ public_sources: [
 private_sources: []
 refdata: []
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 ...

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'hc'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.9.1'
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -65,6 +65,6 @@ refdata: [
   'snpEff-4.3',
 ]
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 ...

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -17,7 +17,7 @@ stack_prefix: 'nb'
 lua_version: '5.1.4.9'
 lmod_version: '7.8.8'
 easybuild_version: '4.9.1'
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -46,6 +46,6 @@ public_sources: [
 private_sources: []
 refdata: []
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 ...

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -19,7 +19,7 @@ luaposix_version: '36.2.1'
 lmod_version: '8.7.32'
 easybuild_version: '4.9.1'
 eb_user: umcg-envsync
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -53,6 +53,6 @@ public_sources: []
 private_sources: []
 refdata: []
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 ...

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -19,7 +19,7 @@ luaposix_version: '36.2.1'
 lmod_version: '8.7.32'
 easybuild_version: '4.9.1'
 eb_user: umcg-envsync
-extra_easyconfigs_version: 24.05.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 #
 # Group folder structures to construct on shared storage systems.
@@ -49,7 +49,7 @@ private_sources: []
 refdata: []
 static_easyconfigs:
   - 'b/BCFtools/BCFtools-1.19-GCCcore-11.3.0.eb'
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
   - 'h/hashdeep/hashdeep-4.4-20180907-18a6b5d-GCCcore-11.3.0.eb'
   - 'h/HDF5/HDF5-1.12.2-gompi-2022a.eb'

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -19,7 +19,7 @@ luaposix_version: '36.2.1'
 lmod_version: '8.7.32'
 easybuild_version: '4.9.1'
 eb_user: umcg-envsync
-extra_easyconfigs_version: 24.11.1
+extra_easyconfigs_version: 25.01.1
 extra_easyconfigs_repository: 'take-it-easyconfigs'
 # extra_easyconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/{{ extra_easyconfigs_repository }}-{{ extra_easyconfigs_version }}/easybuild/easyconfigs/"
 #
@@ -1456,7 +1456,7 @@ refdata: [
   'snpEff-4.3',
 ]
 static_easyconfigs:
-  - 'c/cluster-utils/cluster-utils-v24.04.1-GCCcore-11.3.0.eb'
+  - 'c/cluster-utils/cluster-utils-v25.01.2-GCCcore-11.3.0.eb'
   - 'd/depad-utils/depad-utils-v24.04.1.eb'
 chaperone_only_easyconfigs: "{{ all_easyconfigs | select('search', '(NGS_Automated-.*-bare|depad-utils-.*).eb') | list }}"
 ...


### PR DESCRIPTION
Updated `take-it-easyconfigs` repo version for new `cluster-utils v25.01.2` with updated `quota` command.