### PR TITLE
Updating cronjobs for Trendanalysis-2.1.0

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -593,7 +593,7 @@ group_module_versions:
     ngs-utils: 24.02.2
     vip: v9.2.0
     NGS_Demultiplexing: 2.5.4
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
   umcg-gap:
     NGS_Automated:
       default: 4.2.0
@@ -612,7 +612,7 @@ group_module_versions:
     nf_ngs_dna: 1.4.0
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.02.2
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
   umcg-gsad:
     NGS_Automated:
       default: 4.3.1
@@ -724,7 +724,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-atd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-atd -d all"
+         trendAnalyse.sh -g umcg-atd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     machines: "{{ groups['chaperone'] | default([]) }}"
@@ -975,7 +975,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-gd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-gd -d all"
+         trendAnalyse.sh -g umcg-gd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     disable: true

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -585,7 +585,7 @@ group_module_versions:
     ngs-utils: 24.02.2
     vip: v9.2.0
     NGS_Demultiplexing: 2.5.4
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
   umcg-gap:
     NGS_Automated:
       default: 4.2.0
@@ -605,7 +605,7 @@ group_module_versions:
     nf_ngs_dna: 1.4.0
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.02.2
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
   umcg-gsad:
     NGS_Automated:
       default: 4.3.1
@@ -718,7 +718,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-atd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-atd -d all"
+         trendAnalyse.sh -g umcg-atd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     disable: true
@@ -969,7 +969,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-gd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-gd -d all"
+         trendAnalyse.sh -g umcg-gd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     disable: false

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -492,7 +492,7 @@ group_module_versions:
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.03.1
     NGS_Demultiplexing: 2.5.4
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
     vip: 9.2.0
   umcg-gap:
     NGS_Automated:
@@ -515,7 +515,7 @@ group_module_versions:
     ConcordanceCheck: 3.0.0
     ngs-utils: 24.02.2
     NGS_Demultiplexing: 2.5.4
-    Trendanalysis: 2.0.0
+    Trendanalysis: 2.1.0
   umcg-gsad:
     NGS_Automated:
       default: 4.3.1
@@ -674,7 +674,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-atd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-atd -d all"
+         trendAnalyse.sh -g umcg-atd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-atd-dm
     disable: true
@@ -942,7 +942,7 @@ crontabs:
     hour: '12'
     job: /bin/bash -c "{{ configure_env_in_cronjob }};
          module load Trendanalysis/{{ group_module_versions['umcg-gd']['Trendanalysis'] }};
-         trendAnalyse.sh -g umcg-gd -d all"
+         trendAnalyse.sh -g umcg-gd"
   - name: Trendanalysis_copyTrendAnalysisDataToPrm  # Unique ID required to update existing cronjob: do not modify.
     user: umcg-gd-dm
     disable: true


### PR DESCRIPTION
- Updated cronjobs for umcg-atd and umcg-gd to version 2.1.0
- cronjobs for betabarrel and wingedhelix remain 'disabled = true'
- cronjobs for copperfist remain 'disabled = false' 